### PR TITLE
Update video urls to https

### DIFF
--- a/app/posts/2013-03-21-jasmine-tactics-screencast.md
+++ b/app/posts/2013-03-21-jasmine-tactics-screencast.md
@@ -4,7 +4,7 @@ author:
   name: "Justin Searls"
   url: "http://about.me/searls"
 video:
-  url: "http://www.youtube.com/embed/PWHyE1Ru4X0?rel=0"
+  url: "https://www.youtube.com/embed/PWHyE1Ru4X0?rel=0"
   type: "youtube"
 tldr:
   title: "Practical Jasmine examples"
@@ -26,7 +26,7 @@ some perspective on how to test JavaScript with Jasmine. Folks have been asking
 me to share a screencast of how I write Jasmine tests for a few years, so I
 recorded the session and am providing it online, completely unedited.
 
-This screencast ([YouTube](http://www.youtube.com/watch?v=PWHyE1Ru4X0)) is
+This screencast ([YouTube](https://www.youtube.com/watch?v=PWHyE1Ru4X0)) is
 merely a conversation to provide an answer to the question, "Hey Justin, how
 would you write a test for ____ JavaScript code?" where that blank might be
 filled with "interacting with the DOM", or "binding user events", or "making

--- a/app/posts/2013-06-26-what-polymer-and-angular-tell-us-about-the-future-success-of-the-web-platform-and-javascript-frameworks.md
+++ b/app/posts/2013-06-26-what-polymer-and-angular-tell-us-about-the-future-success-of-the-web-platform-and-javascript-frameworks.md
@@ -2,7 +2,7 @@
 title: "what polymer and angular tell us about the future success of the web platform and javascript frameworks"
 author:
   name: "David Mosher"
-  url: "http://www.youtube.com/user/vidjadavemo/videos"
+  url: "https://www.youtube.com/user/vidjadavemo/videos"
 tldr:
   title: "don\'t try to get everything right upfront"
   body: """
@@ -133,10 +133,10 @@ the upcoming [Web
 Components](http://www.w3.org/TR/2013/WD-components-intro-20130606/) spec.
 [Eric
 Bidelman](https://www.google.ca/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&ved=0CC0QFjAA&url=https%3A%2F%2Ftwitter.com%2Febidel&ei=_EDLUbuIK8iHywGUuYHoDg&usg=AFQjCNHgffvpgL9vHcpCK96uvkRqTmUkzg&bvm=bv.48340889,d.aWc)
-gave a [great overview](http://www.youtube.com/watch?v=fqULJBBEVQE) of it
+gave a [great overview](https://www.youtube.com/watch?v=fqULJBBEVQE) of it
 during Google IO this year and [Alex Komoroske](https://twitter.com/jkomoros)
 and [Matthew McNulty](https://twitter.com/mattsmcnulty) had an [amazing
-demo](http://www.youtube.com/watch?v=0g0oOOT86NY) that showcased some of the
+demo](https://www.youtube.com/watch?v=0g0oOOT86NY) that showcased some of the
 capabilities. I'm excited about Web Components because it will allow web
 developers to experiment at a lower-level by reshaping the way that we write
 markup. It will also offer true encapsulation on the web, a feature that has

--- a/app/posts/2013-07-17-introduction-to-angular-screencast.md
+++ b/app/posts/2013-07-17-introduction-to-angular-screencast.md
@@ -2,9 +2,9 @@
 title: "introduction to angular"
 author:
   name: "Dave Mosher"
-  url: "http://www.youtube.com/user/vidjadavemo/videos"
+  url: "https://www.youtube.com/user/vidjadavemo/videos"
 video:
-  url: "http://www.youtube.com/embed/8ILQOFAgaXE?rel=0"
+  url: "https://www.youtube.com/embed/8ILQOFAgaXE?rel=0"
   type: "youtube"
 ---
 

--- a/app/posts/2013-08-24-office-politics.md
+++ b/app/posts/2013-08-24-office-politics.md
@@ -4,7 +4,7 @@ author:
   name: "Justin Searls"
   url: "http://twitter.com/searls"
 video:
-  url: "http://www.youtube.com/embed/MfK0rTacde8"
+  url: "https://www.youtube.com/embed/MfK0rTacde8"
   type: "youtube"
 ---
 
@@ -12,15 +12,15 @@ video:
 
 I did a presentation about how developers can start to dip their toes in the water of effecting change in their teams and organizations based on my experiences as a consultant navigating highly-charged political environments.
 
-In addition to the [video above](http://www.youtube.com/watch?v=MfK0rTacde8
+In addition to the [video above](https://www.youtube.com/watch?v=MfK0rTacde8
 ), here's a copy of the slides as I presented them at [Madison Ruby](http://madisonruby.org):
 
 <script async="async" class="speakerdeck-embed" data-id="45ad9d00ea63013040c77ee3eec3cdd3" data-ratio="1.33333333333333" src="//speakerdeck.com/assets/embed.js"></script>
 
 I hope you enjoy it! As always, feel free to [reach out to me](mailto:justin@testdouble.com) if you have any feedback!
 
-Below is [video of the talk](http://www.youtube.com/watch?v=amFtMIRBtZs) as I presented it at [Kalamazoo X](http://kalamazoox.org) in April 2013:
+Below is [video of the talk](https://www.youtube.com/watch?v=amFtMIRBtZs) as I presented it at [Kalamazoo X](http://kalamazoox.org) in April 2013:
 
 <div class="embed-container">
-  <iframe src="http://www.youtube.com/embed/amFtMIRBtZs" allowfullscreen="allowfullscreen"></iframe>
+  <iframe src="https://www.youtube.com/embed/amFtMIRBtZs" allowfullscreen="allowfullscreen"></iframe>
 </div>

--- a/app/posts/2013-10-03-javascript-testing-tactics.md
+++ b/app/posts/2013-10-03-javascript-testing-tactics.md
@@ -4,7 +4,7 @@ author:
   name: "Justin Searls"
   url: "http://twitter.com/searls"
 video:
-  url: "http://www.youtube.com/embed/HHcEjAQ46Io"
+  url: "https://www.youtube.com/embed/HHcEjAQ46Io"
   type: "youtube"
 tldr:
   title: "A different approach to JavaScript testing"

--- a/app/posts/2013-11-12-1st-class-web-development-with-lineman.md
+++ b/app/posts/2013-11-12-1st-class-web-development-with-lineman.md
@@ -13,7 +13,7 @@ tldr:
         """
 ---
 
-This talk was delivered at [Øredev](http://www.oredev.com) in Malmö, Sweden. It was a joy to have an entire week to focus on how to best discuss the trends we're experiencing in fat-client JavaScript. As a result, I feel like I finally landed at a sufficient explanation of what [Lineman](http://www.linemanjs.com) is and why it might serve you well. You can [find it on YouTube](https://youtu.be/KERJkJNV5nI).
+This talk was delivered at [Øredev](http://www.oredev.com) in Malmö, Sweden. It was a joy to have an entire week to focus on how to best discuss the trends we're experiencing in fat-client JavaScript. As a result, I feel like I finally landed at a sufficient explanation of what [Lineman](http://www.linemanjs.com) is and why it might serve you well. You can [find it on YouTube](https://www.youtube.com/embed/KERJkJNV5nI).
 
 Here are the slides, hosted on [SpeakerDeck](https://speakerdeck.com/searls/1st-class-web-development-with-lineman):
 

--- a/app/posts/2013-11-12-1st-class-web-development-with-lineman.md
+++ b/app/posts/2013-11-12-1st-class-web-development-with-lineman.md
@@ -4,7 +4,7 @@ author:
   name: "Justin Searls"
   url: "http://twitter.com/searls"
 video:
-  url: "http://www.youtube.com/embed/KERJkJNV5nI"
+  url: "https://www.youtube.com/embed/KERJkJNV5nI"
   type: "youtube"
 tldr:
   title: "Making front-end development more delightful."
@@ -13,7 +13,7 @@ tldr:
         """
 ---
 
-This talk was delivered at [Øredev](http://www.oredev.com) in Malmö, Sweden. It was a joy to have an entire week to focus on how to best discuss the trends we're experiencing in fat-client JavaScript. As a result, I feel like I finally landed at a sufficient explanation of what [Lineman](http://www.linemanjs.com) is and why it might serve you well. You can [find it on YouTube](http://youtu.be/KERJkJNV5nI).
+This talk was delivered at [Øredev](http://www.oredev.com) in Malmö, Sweden. It was a joy to have an entire week to focus on how to best discuss the trends we're experiencing in fat-client JavaScript. As a result, I feel like I finally landed at a sufficient explanation of what [Lineman](http://www.linemanjs.com) is and why it might serve you well. You can [find it on YouTube](https://youtu.be/KERJkJNV5nI).
 
 Here are the slides, hosted on [SpeakerDeck](https://speakerdeck.com/searls/1st-class-web-development-with-lineman):
 

--- a/app/posts/2014-04-19-setting-up-a-serious-ember-project.md
+++ b/app/posts/2014-04-19-setting-up-a-serious-ember-project.md
@@ -5,7 +5,7 @@ author:
   url: "http://twitter.com/searls"
   googlePlus: "https://plus.google.com/+JustinSearlsTestDouble"
 video:
-  url: "http://www.youtube.com/embed/ZauLosiTcbc"
+  url: "https://www.youtube.com/embed/ZauLosiTcbc"
   type: "youtube"
 reddit: true
 tldr:

--- a/app/posts/2014-04-28-enacting-change.md
+++ b/app/posts/2014-04-28-enacting-change.md
@@ -3,11 +3,11 @@ title: "Enacting Change."
 author:
   name: "Todd Kaufman"
   url: "http://twitter.com/toddkaufman"
+video:
+  url: "https://player.vimeo.com/video/69030167"
+  type: "vimeo"
+
 ---
-<div class="embed-container">
-  <iframe src="//player.vimeo.com/video/69030167" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-  <p><a href="http://vimeo.com/69030167">Todd Kaufman - Enacting Change</a> from <a href="http://vimeo.com/kalamazoox">The Kalamazoo X Conference</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
-</div>
 
 Now that the weekend is over, I'm sure many of the people at [KalamazooX](http://www.kalamazoox.org) on Saturday will approach their careers this week with a renewed sense of purpose. If you haven't been to KalX, you really need to check it out because it is a great, single day conference focused on the heart and soul of software developers. Every year speakers share deep, personal, insightful, and meaningful stories that inspire attendees to seek significant change in their own lives.
 

--- a/app/posts/2014-05-02-ember-routes-models-templates-and-controllers.md
+++ b/app/posts/2014-05-02-ember-routes-models-templates-and-controllers.md
@@ -5,7 +5,7 @@ author:
   url: "http://twitter.com/searls"
   googlePlus: "https://plus.google.com/+JustinSearlsTestDouble"
 video:
-  url: "http://www.youtube.com/embed/nS04YzHMqwo"
+  url: "https://www.youtube.com/embed/nS04YzHMqwo"
   type: "youtube"
 reddit: true
 tldr:

--- a/app/posts/2014-05-09-javascript-testing-tactics-lightning-edition.md
+++ b/app/posts/2014-05-09-javascript-testing-tactics-lightning-edition.md
@@ -4,7 +4,7 @@ author:
   name: "Justin Searls"
   url: "http://twitter.com/searls"
 video:
-  url: "http://www.youtube.com/embed/gjx6SijA47I"
+  url: "https://www.youtube.com/embed/gjx6SijA47I"
   type: "youtube"
 ---
 

--- a/app/posts/2014-05-14-mock-objects-in-discovery-tests.md
+++ b/app/posts/2014-05-14-mock-objects-in-discovery-tests.md
@@ -5,7 +5,7 @@ author:
   url: "http://twitter.com/searls"
   googlePlus: "https://plus.google.com/+JustinSearlsTestDouble"
 video:
-  url: "http://www.youtube.com/embed/MkgDPRgt9XU"
+  url: "https://www.youtube.com/embed/MkgDPRgt9XU"
   type: "youtube"
 reddit: true
 ---

--- a/app/posts/2014-05-25-breaking-up-with-your-test-suite.md
+++ b/app/posts/2014-05-25-breaking-up-with-your-test-suite.md
@@ -16,6 +16,6 @@ The most immediate abstraction we have for wrangling the motivations and impleme
 
 This talk is an example of how to do that. Hopefully, it's at just the level of detail you'll need to ponder how to apply a similar approach to your teams and applications.
 
-The [video above](https://www.youtube.com/watch?v=9_3RsSvgRd4&feature=youtu.be) was presented at Ancient City Ruby 2014 on April 3rd, 2014. Its slides are [available on SpeakerDeck](https://speakerdeck.com/searls/breaking-up-with-your-test-suite), as always:
+The [video above](https://www.youtube.com/watch?v=9_3RsSvgRd4) was presented at Ancient City Ruby 2014 on April 3rd, 2014. Its slides are [available on SpeakerDeck](https://speakerdeck.com/searls/breaking-up-with-your-test-suite), as always:
 
 <script async class="speakerdeck-embed" data-id="372e82c09d7501316e28625017dd54d3" data-ratio="1.33333333333333" src="//speakerdeck.com/assets/embed.js"></script>

--- a/app/posts/2014-05-25-breaking-up-with-your-test-suite.md
+++ b/app/posts/2014-05-25-breaking-up-with-your-test-suite.md
@@ -5,7 +5,7 @@ author:
   url: "http://twitter.com/searls"
   googlePlus: "https://plus.google.com/+JustinSearlsTestDouble"
 video:
-  url: "http://www.youtube.com/embed/9_3RsSvgRd4"
+  url: "https://www.youtube.com/embed/9_3RsSvgRd4"
   type: "youtube"
 reddit: true
 ---

--- a/app/posts/2014-07-17-test-angular-like-it-was-made-out-of-javascript.md
+++ b/app/posts/2014-07-17-test-angular-like-it-was-made-out-of-javascript.md
@@ -4,7 +4,7 @@ author:
   name: "Zach Briggs"
   url: "http://twitter.com/theotherzach"
 video:
-  url: "http://www.youtube.com/embed/eFPpSeEhhOE"
+  url: "https://www.youtube.com/embed/eFPpSeEhhOE"
   type: "youtube"
 tldr:
   title: "Misdirection For Profit"

--- a/app/posts/2014-12-02-the-social-coding-contract.md
+++ b/app/posts/2014-12-02-the-social-coding-contract.md
@@ -14,6 +14,6 @@ Social coding revolutionized how we share code with others. Bundler, npm, and Gi
 
 This talk is an opportunity to pause and reflect on our relationship with open source. Convenience and ego drive most open source adoption, but these shortsighted motivations raise long-term problems we need to clearly identify if we can ever hope to solve them. This presentation is just a first step in that direction.
 
-The [video above](https://www.youtube.com/watch?v=HFRU6eQKp4Y&feature=youtu.be) was presented at RubyConf 2014 on November 19, 2014. The slides are [up on SpeakerDeck](https://speakerdeck.com/searls/the-social-coding-contract), as usual.
+The [video above](https://www.youtube.com/watch?v=HFRU6eQKp4Y) was presented at RubyConf 2014 on November 19, 2014. The slides are [up on SpeakerDeck](https://speakerdeck.com/searls/the-social-coding-contract), as usual.
 
 <script async class="speakerdeck-embed" data-id="10177ac0524c01327aec02fb58ce8c77" data-ratio="1.77777777777778" src="//speakerdeck.com/assets/embed.js"></script>

--- a/app/posts/2014-12-02-the-social-coding-contract.md
+++ b/app/posts/2014-12-02-the-social-coding-contract.md
@@ -5,7 +5,7 @@ author:
   url: "http://twitter.com/searls"
   googlePlus: "https://plus.google.com/+JustinSearlsTestDouble"
 video:
-  url: "http://www.youtube.com/embed/HFRU6eQKp4Y"
+  url: "https://www.youtube.com/embed/HFRU6eQKp4Y"
   type: "youtube"
 reddit: true
 ---

--- a/app/posts/2015-02-13-advanced-directives-with-angular-js.md
+++ b/app/posts/2015-02-13-advanced-directives-with-angular-js.md
@@ -2,7 +2,7 @@
 title: "Advanced Directives with Angular JS"
 author:
   name: "Dave Mosher"
-  url: "http://www.youtube.com/user/vidjadavemo/videos"
+  url: "https://www.youtube.com/user/vidjadavemo/videos"
 video:
   url: "https://www.youtube.com/embed/Ty8XcASK9js?rel=0"
   type: "youtube"
@@ -12,7 +12,7 @@ video:
 
 This screencast examines some of the more advanced features in Angular, specifically Directives. We'll see how we can leverage the power of custom elements and attributes to map Domain Specific concepts through HTML and translate those into Value Objects in our Domain, resulting in cleaner HTML output. Also discussed: complexity, creating a DSL with directives, debugging techniques, and other tips and tricks.
 
-If you're interested in some more context prior to watching, check out my other [angular screencasts](http://www.youtube.com/user/vidjadavemo/videos) and an earlier post on the [power of web components as abstractions](http://blog.testdouble.com/posts/2013-06-26-what-polymer-and-angular-tell-us-about-the-future-success-of-the-web-platform-and-javascript-frameworks.html). This screencast covers:
+If you're interested in some more context prior to watching, check out my other [angular screencasts](https://www.youtube.com/user/vidjadavemo/videos) and an earlier post on the [power of web components as abstractions](http://blog.testdouble.com/posts/2013-06-26-what-polymer-and-angular-tell-us-about-the-future-success-of-the-web-platform-and-javascript-frameworks.html). This screencast covers:
 
 * html as a dsl
 * abstractions in html

--- a/app/posts/2015-03-06-dsls-with-javascript-coffeescript.md
+++ b/app/posts/2015-03-06-dsls-with-javascript-coffeescript.md
@@ -2,7 +2,7 @@
 title: "Building DSLs with JavaScript/CoffeeScript"
 author:
   name: "Dave Mosher"
-  url: "http://www.youtube.com/user/vidjadavemo/videos"
+  url: "https://www.youtube.com/user/vidjadavemo/videos"
 video:
   url: "https://www.youtube.com/embed/EOksrrySfwI?rel=0"
   type: "youtube"

--- a/app/posts/2015-04-10-introduction-to-react-native.md
+++ b/app/posts/2015-04-10-introduction-to-react-native.md
@@ -2,7 +2,7 @@
 title: "Introduction to React Native"
 author:
   name: "Dave Mosher"
-  url: "http://www.youtube.com/user/vidjadavemo/videos"
+  url: "https://www.youtube.com/user/vidjadavemo/videos"
 video:
   url: "https://www.youtube.com/embed/n5RhAYhTxCk?rel=0"
   type: "youtube"

--- a/app/posts/2015-05-11-sometimes-a-controller-is-just-a-controller.md
+++ b/app/posts/2015-05-11-sometimes-a-controller-is-just-a-controller.md
@@ -5,7 +5,7 @@ author:
   url: "http://twitter.com/searls"
   googlePlus: "https://plus.google.com/+JustinSearlsTestDouble"
 video:
-  url: "http://www.youtube.com/embed/a6gel0eVeNw"
+  url: "https://www.youtube.com/embed/a6gel0eVeNw"
   type: "youtube"
 reddit: true
 ---

--- a/app/posts/2015-06-08-finding-joy-at-work.md
+++ b/app/posts/2015-06-08-finding-joy-at-work.md
@@ -4,7 +4,7 @@ author:
   name: "Todd Kaufman"
   url: "http://twitter.com/toddkaufman"
 video:
-  url: "http://www.youtube.com/embed/JOoULTXN75o"
+  url: "https://www.youtube.com/embed/JOoULTXN75o"
   type: "youtube"
 ---
 

--- a/app/posts/2015-11-16-how-to-stop-hating-your-tests.md
+++ b/app/posts/2015-11-16-how-to-stop-hating-your-tests.md
@@ -5,7 +5,7 @@ author:
   url: "http://twitter.com/searls"
   googlePlus: "https://plus.google.com/+JustinSearlsTestDouble"
 video:
-  url: "//player.vimeo.com/video/145917204"
+  url: "https://player.vimeo.com/video/145917204"
   type: "vimeo"
 reddit: false
 ---


### PR DESCRIPTION
Many youtube video links were hardcoding http; which were then blocked from loading on https pages.

In addition, this PR replaces a few youtu.be short-links with their canonical url and replaces a couple of hardcoded video embeds with the metadata version.