### PR TITLE
Ports a11y updates from site to blog.

### DIFF
--- a/app/partials/accessible-menu.pug
+++ b/app/partials/accessible-menu.pug
@@ -1,0 +1,49 @@
+script.
+  (function() {
+    function checkbox() {
+      return document.getElementById('navigation-trigger')
+    }
+    function openMenu() {
+      checkbox().checked = true
+      document.getElementsByClassName('primary-nav-item')[0].focus()
+      document.getElementById('logo').setAttribute('tabindex', -1)
+    }
+    function closeMenu() {
+      checkbox().checked = false
+      document.getElementsByClassName('menu-trigger')[0].focus()
+      document.getElementById('logo').setAttribute('tabindex', 0)
+    }
+    function toggleMenu() {
+      var shouldOpen = !checkbox().checked
+      if (shouldOpen) {
+        openMenu()
+      } else {
+        closeMenu()
+      }
+    }
+
+    function isKeyCode(keyCode) {
+      return function(event) {
+        return event.keyCode === keyCode
+      }
+    }
+    var isEscape = isKeyCode(27)
+    var isEnter = isKeyCode(13)
+
+    function toggleMenuOnEnter(event) {
+      isEnter(event) && toggleMenu()
+    }
+    function closeMenuOnEnter(event) {
+      isEnter(event) && closeMenu()
+    }
+    function closeMenuOnEscape(event) {
+      isEscape(event) && closeMenu()
+    }
+    document.querySelectorAll('.menu-close').forEach(function(element) {
+      element.addEventListener('keydown', closeMenuOnEnter, false)
+    })
+    document.querySelectorAll('.menu-trigger').forEach(function(element) {
+      element.addEventListener('keydown', toggleMenuOnEnter, false)
+    })
+    document.addEventListener('keydown', closeMenuOnEscape, false)
+  })()

--- a/app/partials/header.pug
+++ b/app/partials/header.pug
@@ -1,5 +1,5 @@
 header(class=`primary-header ${darkHeader}` role="banner")
-  a(href="//testdouble.com")
+  a(id="logo" href="//testdouble.com")
     h1(class=`primary-header-item logo ${darkHeader}`) Test Double
   label(for="navigation-trigger" role="button")
-    .menu-trigger(class=`primary-header-item ${darkHeader}`)
+    .menu-trigger(class=`primary-header-item ${darkHeader}` tabindex='0' aria-label='Toggle Navigation' aria-controls='sidebar-navigation')

--- a/app/partials/navigation.pug
+++ b/app/partials/navigation.pug
@@ -1,6 +1,6 @@
-aside(class="primary-nav-sidebar" role="complimentary")
+aside(id="sidebar-navigation" class="primary-nav-sidebar" role="complimentary")
   label.navigation-close(for="navigation-trigger" role="button")
-    .menu-close
+    .menu-close(tabindex='0' aria-label='Close Navigation')
   nav(class="primary-nav" role="navigation")
     a(href="//testdouble.com/agency.html" class="primary-nav-item") Our Agency
     a(href="//testdouble.com/work.html" class="primary-nav-item") Our Work

--- a/app/templates/wrapper.pug
+++ b/app/templates/wrapper.pug
@@ -30,5 +30,6 @@ html(lang="en")
 
   body
     input.is-nav-trigger#navigation-trigger(type="checkbox")
-    main(class="site-container" role="main").content !{yield}
     include ../partials/navigation.pug
+    main(class="site-container").content !{yield}
+    include ../partials/accessible-menu.pug

--- a/vendor/css/components/navigation.sass
+++ b/vendor/css/components/navigation.sass
@@ -54,9 +54,6 @@ $navigation-items: 4
   @include size(44px 39px)
   background: url(/img/close-menu-icon.svg) center no-repeat
 
-  &:focus
-    outline: none
-
 .social
   .icon
     height: 20px


### PR DESCRIPTION
- Allows keyboard navigation to open/close side nav
- Moves focus to first element in side nav when opened with keyboard
- Moves focus out of side nav when closed with keyboard
- Shows focus outline on close button
- Close side nav with escape
- Reorders dom for better tab navigation

This closes #78 and is a companion PR to https://github.com/testdouble/site/pull/32/