### PR TITLE
Removes copy config option.

### DIFF
--- a/config/application.coffee
+++ b/config/application.coffee
@@ -23,12 +23,6 @@ module.exports = (lineman) ->
       title: "<%= pkg.title %>"
       dateFormat: 'MMMM Do, YYYY'
 
-  copy:
-    dev:
-      files: [ expand: true, cwd: 'static', src: '**', dest: 'generated' ]
-    dist:
-      files: [ expand: true, cwd: 'static', src: '**', dest: 'dist' ]
-
   htmlhint:
     files:
       src: "generated/**/*.html"


### PR DESCRIPTION
The current copy config options seems to have been created before it was
a part of
[lineman](https://github.com/linemanjs/lineman/blob/3f828e5b96b72c6a9d562a0dba23e8f2cd4d2cfc/config/plugins/copy.coffee).

This removes the custom, broken configuration so that the default is
used instead.

Items placed in `app/static` will now be served at the root
(`localhost:8080/` for dev)