### PR TITLE
Adds ability to define description on posts for meta descriptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ So here's an example post, with all the goodies filled out.
 ``` markdown
 ---
 title: "Kramer sure is super cool"
+description: "Kramer writes good meta descriptions for the google juice"
 tldr:
   title: "Kramer writes great code"
   body: """

--- a/app/partials/head.pug
+++ b/app/partials/head.pug
@@ -1,6 +1,7 @@
 head
   meta(http-equiv="Content-Type" content="text/html; charset=UTF-8")
   meta(name="viewport" content="width=device-width, maximum-scale=1.0, user-scalable=no")
+  meta(name="description" content=`${( post && post.get('description')) || "Test Double is an agency of highly-skilled developers on a mission to improve how the world writes software. Need JavaScript or Ruby help? hello@testdouble.com"}`)
   title #{site.title}#{post ? ' | ' + post.title() : ''}
   link(rel="alternate" type="application/rss+xml" title=`${site.title} | feed` href="/index.xml")
   link(rel='shortcut icon' type='image/x-icon' href='favicon.ico')

--- a/app/posts/2017-01-05-react-d3.md
+++ b/app/posts/2017-01-05-react-d3.md
@@ -1,5 +1,6 @@
 ---
 title: "A Well Factored Pie Graph: React + D3"
+description: "A technologist's most powerful skill is the ability to analyze and leverage a tool's strengths. React and D3 have different strengths, which work well together to build a complex visualization."
 date: "2017-01-05"
 author:
   name: "Sam Jones"

--- a/app/posts/2017-01-18-life-after-nil.md
+++ b/app/posts/2017-01-18-life-after-nil.md
@@ -1,5 +1,6 @@
 ---
 title: "Life After Nil"
+description: 'Learn about the benifits that a type system can add to your coding by comparing Ruby to Haskell. We will “forget about nil”, “declaratively model your domain”, and “allow your compiler to drive your design”.'
 author:
   name: "Sam Jones"
   url: "http://twitter.com/samjonester"

--- a/app/posts/2017-01-27-a-better-technical-interview.md
+++ b/app/posts/2017-01-27-a-better-technical-interview.md
@@ -1,5 +1,6 @@
 ---
 title: "A Better Technical Interview"
+description: "It's easy to find fault in the way we interview in tech. Let's analyze the things we don't like, and design a better process. Let's make a better technical interview with honesty, transparency, and a more realistic experience."
 author:
   name: "Sam Jones"
   url: "http://twitter.com/samjonester"

--- a/app/posts/2017-02-17-test-organization-with-contexts.md
+++ b/app/posts/2017-02-17-test-organization-with-contexts.md
@@ -1,5 +1,6 @@
 ---
 title: "Test Organization With Contexts"
+description: "When testing we create a test file for each class. This practice recognizes that classes group common behavior and ideas.  We can extend this idea further by using test contexts around the natural shared contexts of a subject under test."
 author:
   name: "Sam Jones"
   url: "http://twitter.com/samjonester"

--- a/app/posts/2017-04-07-accessibility-is-usability.md
+++ b/app/posts/2017-04-07-accessibility-is-usability.md
@@ -1,5 +1,6 @@
 ---
 title: "Accessibility Is Usability"
+description: "Accessibility guidelines exist to eliminate barriers that would otherwise hinder equal access to a significant percentage of the population. The great thing about following accessibility guidelines is that techniques have an impact on all users. Getting started with accessibility is easy, and any action you take benefits users now!"
 subtitle: "How Accessibility Improvements Help Everyone"
 author:
   name: "Sam Jones"

--- a/app/posts/2017-04-28-accessibility-impactful-techniques.md
+++ b/app/posts/2017-04-28-accessibility-impactful-techniques.md
@@ -1,5 +1,6 @@
 ---
 title: "Accessibility Techniques"
+description: "Accessibility techniques are a way to create a more usable experience for all users. This post covers accessibility techniques that are most likely to fix issues that block users with disabilities from successfully navigating your application, and techniques that create a more inclusive experience and provide equal access to even more people."
 subtitle: "Impactful Tools and Techniques to Get You Started"
 author:
   name: "Sam Jones"


### PR DESCRIPTION
A new description field is added to the meta content at the top of a post's markdown file. This is used to generate the <meta name="description"/> tag.

Also adds descriptions to @samjonester 's posts as an example.