### PR TITLE
Fix broken JS in IE11 (and maybe other browsers?)

### DIFF
--- a/app/partials/accessible-menu.pug
+++ b/app/partials/accessible-menu.pug
@@ -39,10 +39,10 @@ script.
     function closeMenuOnEscape(event) {
       isEscape(event) && closeMenu()
     }
-    document.querySelectorAll('.menu-close').forEach(function(element) {
+    Array.prototype.forEach.call(document.querySelectorAll('.menu-close'), function(element) {
       element.addEventListener('keydown', closeMenuOnEnter, false)
     })
-    document.querySelectorAll('.menu-trigger').forEach(function(element) {
+    Array.prototype.forEach.call(document.querySelectorAll('.menu-trigger'), function(element) {
       element.addEventListener('keydown', toggleMenuOnEnter, false)
     })
     document.addEventListener('keydown', closeMenuOnEscape, false)


### PR DESCRIPTION
I'm not sure this is causing any user-visible issues, but fixing this prevents an exception being raised on load in (at least) IE11. I imagine at least _some_ other browsers must be affected.

**UPDATE**
Looks like it's only IE/Edge that are missing the `forEach` method on `NodeList`s: https://developer.mozilla.org/en-US/docs/Web/API/NodeList