### PR TITLE
Fix site in IE11

### DIFF
--- a/vendor/css/base/globals.sass
+++ b/vendor/css/base/globals.sass
@@ -5,6 +5,9 @@ body
   padding: $small-spacing
   color: $black
 
+main
+  display: block
+
 .site-container
   background: $white
 


### PR DESCRIPTION
Turns out IE11 doesn't support the `main` tag?! And for some reason, doesn't properly default unknown tags to `display: block;`. See https://weblog.west-wind.com/posts/2015/Jan/12/main-HTML5-Tag-not-working-in-Internet-Explorer-91011