### PR TITLE
Add date to posts

### DIFF
--- a/app/css/blog/components/byline.sass
+++ b/app/css/blog/components/byline.sass
@@ -1,11 +1,19 @@
-.byline
-  @include scale-with-screen(font-size, $type-primary, 1.1, 1.2, 1.3)
-  text-align: right
+.byline-wrapper
+  line-height: $base-line-height;
   margin-right: 10px
   margin-bottom: 20px
+  text-align: right
 
-  a
-    text-decoration: none
-    &:hover
-      text-decoration: underline
+  .byline
+    @include scale-with-screen(font-size, $type-primary, 1.1, 1.2, 1.3)
+
+    a
+      text-decoration: none
+      &:hover
+        text-decoration: underline
+
+  .post-date
+    @include scale-with-screen(font-size, $type-small, 1.1, 1.2, 1.3)
+    color: $dark-grey
+    font-weight: 300;
 

--- a/app/templates/post.pug
+++ b/app/templates/post.pug
@@ -28,12 +28,15 @@ div(data-name="post")
         h3 !{post.get('tldr').title}
         p !{post.get('tldr').body}
     | !{post.content()}
-    if post.get('author')
-      .byline &mdash;
-        if post.get('author').url
-          a(href=post.get('author').url)  #{post.get('author').name}
-        else
-           #{post.get('author').name}
+    .byline-wrapper
+      if post.get('author')
+        .byline &mdash;
+          if post.get('author').url
+            a(href=post.get('author').url)  #{post.get('author').name}
+          else
+             #{post.get('author').name}
+      if post.get('date')
+        time.post-date #{post.get('date')}
 
     if !post.get('skipFeedbackRequest')
       p.call-for-feedback

--- a/app/templates/post.pug
+++ b/app/templates/post.pug
@@ -35,8 +35,7 @@ div(data-name="post")
             a(href=post.get('author').url)  #{post.get('author').name}
           else
              #{post.get('author').name}
-      if post.get('date')
-        time.post-date #{post.get('date')}
+      time.post-date #{post.get('date') || post.path.match(/\d\d\d\d-\d\d-\d\d/)[0]}
 
     if !post.get('skipFeedbackRequest')
       p.call-for-feedback


### PR DESCRIPTION
This is #117 but infers the date from the slug if the `date` isn't in the cson frontmatter instead of editing all the existing posts. 

In general I try to avoid any required fields from the various posts, both because DRY and because things like dates are tricky enough that I wouldn't want to create shit work for folks in the form of having to remember that you must add a date and that we always format dates `YYYY-MM-DD`. (Of course, if a post has a custom `date` in the frontmatter it'll use that in the byline)

cc/ @rosston for :+1: before I merge.