### PR TITLE
Updates package-lock.json for security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "7.0.1"
+        "@types/babel-types": "*"
       }
     },
     "StringScanner": {
@@ -37,7 +37,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -53,7 +53,7 @@
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -88,10 +88,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "align-text": {
@@ -100,9 +100,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -141,8 +141,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.4"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -151,7 +151,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-find-index": {
@@ -229,8 +229,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-types": {
@@ -239,10 +239,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.5",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
         "lodash": {
@@ -265,7 +265,7 @@
       "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
       "dev": true,
       "requires": {
-        "underscore": "1.8.3"
+        "underscore": ">=1.8.3"
       },
       "dependencies": {
         "underscore": {
@@ -307,7 +307,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "better-assert": {
@@ -331,7 +331,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "body-parser": {
@@ -341,15 +341,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.2",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "bytes": {
@@ -381,7 +381,7 @@
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "dev": true,
       "requires": {
-        "hoek": "0.9.1"
+        "hoek": "0.9.x"
       }
     },
     "bourbon": {
@@ -396,7 +396,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -424,7 +424,7 @@
       "integrity": "sha1-yImSRkqOKm7ehpMDdfkrWAd++Xw=",
       "dev": true,
       "requires": {
-        "burrito": "0.2.12"
+        "burrito": ">=0.2.5 <0.3"
       }
     },
     "burrito": {
@@ -433,8 +433,8 @@
       "integrity": "sha1-0NbmrIHV6ZeJxvpKzLCwAx6lT2s=",
       "dev": true,
       "requires": {
-        "traverse": "0.5.2",
-        "uglify-js": "1.1.1"
+        "traverse": "~0.5.1",
+        "uglify-js": "~1.1.1"
       },
       "dependencies": {
         "traverse": {
@@ -475,8 +475,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "caseless": {
@@ -491,8 +491,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -501,11 +501,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "character-parser": {
@@ -514,7 +514,7 @@
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
       "dev": true,
       "requires": {
-        "is-regex": "1.0.4"
+        "is-regex": "^1.0.3"
       }
     },
     "charm": {
@@ -523,7 +523,7 @@
       "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "clean-css": {
@@ -532,7 +532,7 @@
       "integrity": "sha1-5uDZd4YEZjY9kRChdCPSfNaHQwA=",
       "dev": true,
       "requires": {
-        "commander": "1.3.2"
+        "commander": "1.3.x"
       },
       "dependencies": {
         "commander": {
@@ -541,7 +541,7 @@
           "integrity": "sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=",
           "dev": true,
           "requires": {
-            "keypress": "0.1.0"
+            "keypress": "0.1.x"
           }
         }
       }
@@ -552,7 +552,7 @@
       "integrity": "sha1-ePlIXNFhtWbppsctcXDEJw6B22E=",
       "dev": true,
       "requires": {
-        "glob": "7.0.6"
+        "glob": ">= 3.1.4"
       }
     },
     "cliui": {
@@ -561,9 +561,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "co": {
@@ -652,7 +652,7 @@
         "bytes": "0.2.0",
         "cookie": "0.1.0",
         "cookie-signature": "1.0.1",
-        "debug": "0.7.4",
+        "debug": "*",
         "fresh": "0.2.0",
         "methods": "0.0.1",
         "multiparty": "2.1.8",
@@ -682,7 +682,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "console-control-strings": {
@@ -703,10 +703,10 @@
       "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "7.0.1",
-        "@types/babylon": "6.16.2",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0"
+        "@types/babel-types": "^7.0.0",
+        "@types/babylon": "^6.16.2",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0"
       }
     },
     "content-disposition": {
@@ -757,9 +757,9 @@
       "integrity": "sha1-PDwDmxsktIt0qG99/tcKV6TRRYI=",
       "dev": true,
       "requires": {
-        "graceful-fs": "1.2.3",
-        "mkdirp": "0.3.5",
-        "rimraf": "2.0.3"
+        "graceful-fs": "~1.2.0",
+        "mkdirp": "~0.3.4",
+        "rimraf": "~2.0.2"
       },
       "dependencies": {
         "graceful-fs": {
@@ -780,7 +780,7 @@
           "integrity": "sha1-9QopZecUTpr9mYmC8V33BnMPVqk=",
           "dev": true,
           "requires": {
-            "graceful-fs": "1.1.14"
+            "graceful-fs": "~1.1"
           },
           "dependencies": {
             "graceful-fs": {
@@ -800,8 +800,8 @@
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.2.14"
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
       },
       "dependencies": {
         "lru-cache": {
@@ -810,8 +810,8 @@
           "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         }
       }
@@ -823,7 +823,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "boom": "0.4.2"
+        "boom": "0.4.x"
       }
     },
     "cson-safe": {
@@ -841,16 +841,17 @@
           "integrity": "sha1-D9e4QXNA3Q0zno9v2LS4cWlW6NU=",
           "dev": true,
           "requires": {
-            "StringScanner": "0.0.3",
+            "StringScanner": "~0.0.3",
             "cscodegen": "git://github.com/michaelficarra/cscodegen.git#73fd7202ac086c26f18c9d56f025b18b3c6f5383",
-            "escodegen": "0.0.28",
-            "esmangle": "0.0.17",
-            "nopt": "2.1.2",
+            "escodegen": "~0.0.24",
+            "esmangle": "~0.0.8",
+            "nopt": "~2.1.2",
             "source-map": "0.1.11"
           }
         },
         "cscodegen": {
           "version": "git://github.com/michaelficarra/cscodegen.git#73fd7202ac086c26f18c9d56f025b18b3c6f5383",
+          "from": "cscodegen@git://github.com/michaelficarra/cscodegen.git#73fd7202ac086c26f18c9d56f025b18b3c6f5383",
           "dev": true,
           "optional": true
         },
@@ -860,7 +861,7 @@
           "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
           "dev": true,
           "requires": {
-            "abbrev": "1.1.1"
+            "abbrev": "1"
           }
         },
         "source-map": {
@@ -870,7 +871,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -881,7 +882,7 @@
       "integrity": "sha1-OmoE51Zcjp0ZvrSXZ8fslug2WAU=",
       "dev": true,
       "requires": {
-        "parserlib": "0.2.5"
+        "parserlib": "~0.2.2"
       }
     },
     "ctype": {
@@ -897,7 +898,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "dargs": {
@@ -906,7 +907,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "dashdash": {
@@ -915,7 +916,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -938,8 +939,8 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
       }
     },
     "debug": {
@@ -960,15 +961,15 @@
       "integrity": "sha1-0hMjPv4GbM2A2RTXk/GzDNmEuEc=",
       "dev": true,
       "requires": {
-        "adm-zip": "0.4.7",
-        "ext-name": "1.0.1",
-        "get-stdin": "0.1.0",
-        "mkdirp": "0.3.5",
-        "nopt": "2.2.1",
-        "rimraf": "2.2.8",
-        "stream-combiner": "0.0.4",
-        "tar": "0.1.20",
-        "tempfile": "0.1.3"
+        "adm-zip": "^0.4.3",
+        "ext-name": "^1.0.0",
+        "get-stdin": "^0.1.0",
+        "mkdirp": "^0.3.5",
+        "nopt": "^2.2.0",
+        "rimraf": "^2.2.2",
+        "stream-combiner": "^0.0.4",
+        "tar": "^0.1.18",
+        "tempfile": "^0.1.2"
       },
       "dependencies": {
         "fstream": {
@@ -977,10 +978,10 @@
           "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "3.0.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.2.8"
+            "graceful-fs": "~3.0.2",
+            "inherits": "~2.0.0",
+            "mkdirp": "0.5",
+            "rimraf": "2"
           },
           "dependencies": {
             "mkdirp": {
@@ -1006,7 +1007,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.1"
+            "natives": "^1.1.0"
           }
         },
         "minimist": {
@@ -1027,7 +1028,7 @@
           "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
           "dev": true,
           "requires": {
-            "abbrev": "1.1.1"
+            "abbrev": "1"
           }
         },
         "tar": {
@@ -1036,9 +1037,9 @@
           "integrity": "sha1-QpQLrltfIsdEg2mRJvnz8nRJyxM=",
           "dev": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "0.1.31",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "~0.1.28",
+            "inherits": "2"
           }
         }
       }
@@ -1092,9 +1093,9 @@
       "integrity": "sha1-qyOzH1ZJtvqo49KsvTNEZzZcpvo=",
       "dev": true,
       "requires": {
-        "charm": "0.1.2",
-        "deep-is": "0.1.3",
-        "traverse": "0.6.6"
+        "charm": "0.1.x",
+        "deep-is": "0.1.x",
+        "traverse": "0.6.x"
       },
       "dependencies": {
         "charm": {
@@ -1117,8 +1118,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -1147,7 +1148,7 @@
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -1156,8 +1157,8 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "duplexer": {
@@ -1172,8 +1173,8 @@
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "dev": true,
       "requires": {
-        "onetime": "1.1.0",
-        "set-immediate-shim": "1.0.1"
+        "onetime": "^1.0.0",
+        "set-immediate-shim": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -1183,7 +1184,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ee-first": {
@@ -1221,7 +1222,7 @@
         "cookie": "0.3.1",
         "debug": "2.3.3",
         "engine.io-parser": "1.3.2",
-        "ws": "1.1.5"
+        "ws": "~1.1.5"
       },
       "dependencies": {
         "accepts": {
@@ -1230,7 +1231,7 @@
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
           "dev": true,
           "requires": {
-            "mime-types": "2.1.18",
+            "mime-types": "~2.1.11",
             "negotiator": "0.6.1"
           }
         },
@@ -1272,7 +1273,7 @@
         "parsejson": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "1.1.5",
+        "ws": "~1.1.5",
         "xmlhttprequest-ssl": "1.5.3",
         "yeast": "0.1.2"
       },
@@ -1326,7 +1327,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "escape-html": {
@@ -1348,9 +1349,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "esprima": "1.0.4",
-        "estraverse": "1.3.2",
-        "source-map": "0.4.4"
+        "esprima": "~1.0.2",
+        "estraverse": "~1.3.0",
+        "source-map": ">= 0.1.2"
       },
       "dependencies": {
         "esprima": {
@@ -1368,7 +1369,7 @@
       "integrity": "sha1-dZ3OhJbEJI/sLQyq9BCLzz8af10=",
       "dev": true,
       "requires": {
-        "estraverse": "2.0.0"
+        "estraverse": "^2.0.0"
       },
       "dependencies": {
         "estraverse": {
@@ -1386,13 +1387,13 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "escodegen": "0.0.28",
-        "escope": "1.0.3",
-        "esprima": "1.0.4",
-        "esshorten": "0.0.2",
-        "estraverse": "1.3.2",
-        "optimist": "0.6.1",
-        "source-map": "0.1.43"
+        "escodegen": "~ 0.0.28",
+        "escope": "~ 1.0.0",
+        "esprima": "~ 1.0.2",
+        "esshorten": "~ 0.0.2",
+        "estraverse": "~ 1.3.2",
+        "optimist": "*",
+        "source-map": "~ 0.1.8"
       },
       "dependencies": {
         "esprima": {
@@ -1409,7 +1410,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -1427,8 +1428,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "escope": "1.0.3",
-        "estraverse": "1.2.0"
+        "escope": "~ 1.0.0",
+        "estraverse": "~ 1.2.0"
       },
       "dependencies": {
         "estraverse": {
@@ -1487,7 +1488,7 @@
         "connect": "2.9.0",
         "cookie": "0.1.0",
         "cookie-signature": "1.0.1",
-        "debug": "0.7.4",
+        "debug": "*",
         "fresh": "0.2.0",
         "methods": "0.0.1",
         "mkdirp": "0.3.5",
@@ -1501,7 +1502,7 @@
           "integrity": "sha1-/VcTv6FTx9bMWZN4patMRcU1Ap4=",
           "dev": true,
           "requires": {
-            "keypress": "0.1.0"
+            "keypress": "0.1.x"
           }
         },
         "mkdirp": {
@@ -1518,7 +1519,7 @@
       "integrity": "sha1-NhTV8pn0pZKolinn3oJfF3TRmr0=",
       "dev": true,
       "requires": {
-        "got": "0.2.0"
+        "got": "^0.2.0"
       }
     },
     "ext-name": {
@@ -1527,8 +1528,8 @@
       "integrity": "sha1-GCgzVtxAo5NFXFRGDwWZzpfTDgw=",
       "dev": true,
       "requires": {
-        "ext-list": "0.2.0",
-        "underscore.string": "2.3.3"
+        "ext-list": "^0.2.0",
+        "underscore.string": "~2.3.3"
       },
       "dependencies": {
         "underscore.string": {
@@ -1575,16 +1576,16 @@
       "integrity": "sha1-ID+eHINkP3sr+yrPIbfjTfe6AmE=",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "coffee-script": "1.12.7",
-        "cpr": "0.2.0",
-        "cson-safe": "0.1.1",
-        "decompress": "0.2.5",
-        "mkdirp": "0.5.1",
-        "request": "2.83.0",
-        "rimraf": "2.2.8",
-        "underscore": "1.8.3",
-        "which": "1.2.14"
+        "async": "^0.9.0",
+        "coffee-script": "^1.7.1",
+        "cpr": "^0.2.0",
+        "cson-safe": "^0.1.1",
+        "decompress": "^0.2.3",
+        "mkdirp": "^0.5.0",
+        "request": "^2.36.0",
+        "rimraf": "^2.2.8",
+        "underscore": "^1.6.0",
+        "which": "^1.0.5"
       },
       "dependencies": {
         "assert-plus": {
@@ -1611,7 +1612,7 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         },
         "coffee-script": {
@@ -1626,7 +1627,7 @@
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "cryptiles": {
@@ -1635,7 +1636,7 @@
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "dev": true,
           "requires": {
-            "boom": "5.2.0"
+            "boom": "5.x.x"
           },
           "dependencies": {
             "boom": {
@@ -1644,7 +1645,7 @@
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
-                "hoek": "4.2.1"
+                "hoek": "4.x.x"
               }
             }
           }
@@ -1667,9 +1668,9 @@
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
+            "asynckit": "^0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
+            "mime-types": "^2.1.12"
           }
         },
         "hawk": {
@@ -1678,10 +1679,10 @@
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.1",
-            "sntp": "2.1.0"
+            "boom": "4.x.x",
+            "cryptiles": "3.x.x",
+            "hoek": "4.x.x",
+            "sntp": "2.x.x"
           }
         },
         "hoek": {
@@ -1696,9 +1697,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "oauth-sign": {
@@ -1719,28 +1720,28 @@
           "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           }
         },
         "sntp": {
@@ -1749,7 +1750,7 @@
           "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         },
         "tunnel-agent": {
@@ -1758,7 +1759,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "underscore": {
@@ -1787,8 +1788,8 @@
       "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
       "dev": true,
       "requires": {
-        "glob": "3.2.11",
-        "minimatch": "0.4.0"
+        "glob": "3.x",
+        "minimatch": "0.x"
       },
       "dependencies": {
         "glob": {
@@ -1797,8 +1798,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "inherits": "2",
+            "minimatch": "0.3"
           },
           "dependencies": {
             "minimatch": {
@@ -1807,8 +1808,8 @@
               "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
               "dev": true,
               "requires": {
-                "lru-cache": "2.3.1",
-                "sigmund": "1.0.1"
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
               }
             }
           }
@@ -1819,8 +1820,8 @@
           "integrity": "sha1-vSx9Bg0sjI/Xzefx8u0tWycP2xs=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.3.1",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -1832,12 +1833,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1857,8 +1858,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "findup-sync": {
@@ -1867,7 +1868,7 @@
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
       "requires": {
-        "glob": "5.0.15"
+        "glob": "~5.0.0"
       },
       "dependencies": {
         "glob": {
@@ -1876,11 +1877,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -1891,10 +1892,10 @@
       "integrity": "sha1-YCMhjiFciuYorFEFpg5HClCYP28=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
+        "async": "~0.2.9",
         "is-type": "0.0.1",
-        "lodash": "2.3.0",
-        "minimatch": "0.2.14"
+        "lodash": "~2.3.0",
+        "minimatch": "~0.2.9"
       },
       "dependencies": {
         "async": {
@@ -1915,8 +1916,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.3.1",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -1934,9 +1935,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "0.9.2",
-        "combined-stream": "0.0.7",
-        "mime": "1.2.11"
+        "async": "~0.9.0",
+        "combined-stream": "~0.0.4",
+        "mime": "~1.2.11"
       },
       "dependencies": {
         "async": {
@@ -1978,10 +1979,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.2.8"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "function-bind": {
@@ -1996,14 +1997,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "gaze": {
@@ -2012,7 +2013,7 @@
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "requires": {
-        "globule": "1.2.0"
+        "globule": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -2039,7 +2040,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -2068,12 +2069,12 @@
       "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globule": {
@@ -2082,9 +2083,9 @@
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4"
+        "glob": "~7.1.1",
+        "lodash": "~4.17.4",
+        "minimatch": "~3.0.2"
       },
       "dependencies": {
         "glob": {
@@ -2093,12 +2094,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "lodash": {
@@ -2115,7 +2116,7 @@
       "integrity": "sha1-0Awkiyn9zK6pQN+coJlev/MbUaU=",
       "dev": true,
       "requires": {
-        "object-assign": "0.3.1"
+        "object-assign": "^0.3.0"
       },
       "dependencies": {
         "object-assign": {
@@ -2150,22 +2151,22 @@
       "integrity": "sha1-TmpeaVtwRy/VME9fqeNCNoNqc7w=",
       "dev": true,
       "requires": {
-        "coffeescript": "1.10.0",
-        "dateformat": "1.0.12",
-        "eventemitter2": "0.4.14",
-        "exit": "0.1.2",
-        "findup-sync": "0.3.0",
-        "glob": "7.0.6",
-        "grunt-cli": "1.2.0",
-        "grunt-known-options": "1.1.0",
-        "grunt-legacy-log": "1.0.0",
-        "grunt-legacy-util": "1.0.0",
-        "iconv-lite": "0.4.19",
-        "js-yaml": "3.5.5",
-        "minimatch": "3.0.4",
-        "nopt": "3.0.6",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.2.8"
+        "coffeescript": "~1.10.0",
+        "dateformat": "~1.0.12",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.3.0",
+        "glob": "~7.0.0",
+        "grunt-cli": "~1.2.0",
+        "grunt-known-options": "~1.1.0",
+        "grunt-legacy-log": "~1.0.0",
+        "grunt-legacy-util": "~1.0.0",
+        "iconv-lite": "~0.4.13",
+        "js-yaml": "~3.5.2",
+        "minimatch": "~3.0.2",
+        "nopt": "~3.0.6",
+        "path-is-absolute": "~1.0.0",
+        "rimraf": "~2.2.8"
       },
       "dependencies": {
         "grunt-cli": {
@@ -2174,10 +2175,10 @@
           "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
           "dev": true,
           "requires": {
-            "findup-sync": "0.3.0",
-            "grunt-known-options": "1.1.0",
-            "nopt": "3.0.6",
-            "resolve": "1.1.7"
+            "findup-sync": "~0.3.0",
+            "grunt-known-options": "~1.1.0",
+            "nopt": "~3.0.6",
+            "resolve": "~1.1.0"
           }
         }
       }
@@ -2188,7 +2189,7 @@
       "integrity": "sha1-z4KK9zVpTGO1730xNDH9joh3peM=",
       "dev": true,
       "requires": {
-        "lodash": "2.4.2"
+        "lodash": "~2.4.1"
       },
       "dependencies": {
         "lodash": {
@@ -2214,7 +2215,7 @@
           "integrity": "sha1-n3BNDWnZ4TioG63267T94z0VHGE=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -2225,7 +2226,7 @@
       "integrity": "sha1-9T397ghJsce0Dp67umn0jExgecU=",
       "dev": true,
       "requires": {
-        "rimraf": "2.2.8"
+        "rimraf": "~2.2.1"
       }
     },
     "grunt-contrib-coffee": {
@@ -2234,7 +2235,7 @@
       "integrity": "sha1-ixIme3TnM4sfKcW4txj7n4mYLxM=",
       "dev": true,
       "requires": {
-        "coffee-script": "1.6.3"
+        "coffee-script": "~1.6.2"
       },
       "dependencies": {
         "coffee-script": {
@@ -2257,8 +2258,8 @@
       "integrity": "sha1-U05jK/4ZUhshw2RncVe4sR4XPvw=",
       "dev": true,
       "requires": {
-        "clean-css": "1.0.12",
-        "grunt-lib-contrib": "0.6.1"
+        "clean-css": "~1.0.4",
+        "grunt-lib-contrib": "~0.6.0"
       }
     },
     "grunt-contrib-handlebars": {
@@ -2267,9 +2268,9 @@
       "integrity": "sha1-e5JS/QUy1JushuMLHgv5Qd/1nPo=",
       "dev": true,
       "requires": {
-        "chalk": "0.4.0",
-        "grunt-lib-contrib": "0.5.3",
-        "handlebars": "1.3.0"
+        "chalk": "~0.4.0",
+        "grunt-lib-contrib": "~0.5.1",
+        "handlebars": "~1.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2284,9 +2285,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
           }
         },
         "grunt-lib-contrib": {
@@ -2312,9 +2313,9 @@
       "integrity": "sha1-Np2QmyWTxA6L55lAshNAhQx5Oaw=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "hooker": "0.2.3",
-        "jshint": "2.9.5"
+        "chalk": "^1.1.1",
+        "hooker": "^0.2.3",
+        "jshint": "~2.9.4"
       },
       "dependencies": {
         "cli": {
@@ -2324,7 +2325,7 @@
           "dev": true,
           "requires": {
             "exit": "0.1.2",
-            "glob": "7.1.2"
+            "glob": "^7.1.1"
           }
         },
         "glob": {
@@ -2333,12 +2334,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "jshint": {
@@ -2347,14 +2348,14 @@
           "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
           "dev": true,
           "requires": {
-            "cli": "1.0.1",
-            "console-browserify": "1.1.0",
-            "exit": "0.1.2",
-            "htmlparser2": "3.8.3",
-            "lodash": "3.7.0",
-            "minimatch": "3.0.4",
-            "shelljs": "0.3.0",
-            "strip-json-comments": "1.0.4"
+            "cli": "~1.0.0",
+            "console-browserify": "1.1.x",
+            "exit": "0.1.x",
+            "htmlparser2": "3.8.x",
+            "lodash": "3.7.x",
+            "minimatch": "~3.0.2",
+            "shelljs": "0.3.x",
+            "strip-json-comments": "1.0.x"
           }
         },
         "lodash": {
@@ -2377,8 +2378,8 @@
       "integrity": "sha1-vWdqJ1j5dta2kjGZfZ5rnWCgr60=",
       "dev": true,
       "requires": {
-        "grunt-lib-contrib": "0.5.3",
-        "lodash": "1.0.2"
+        "grunt-lib-contrib": "~0.5.1",
+        "lodash": "~1.0.0"
       },
       "dependencies": {
         "grunt-lib-contrib": {
@@ -2404,19 +2405,20 @@
       "integrity": "sha1-tSWlwK/wRiL3Vw4x+SQQbxb4G0Y=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "pug": "2.0.0-rc.4"
+        "chalk": "^1.0.0",
+        "pug": "^2.0.0-alpha3"
       }
     },
     "grunt-contrib-sass": {
       "version": "github:linemanjs/grunt-contrib-sass#cac384efe5facc3dcd44e947925239b3d9cd2252",
+      "from": "grunt-contrib-sass@github:linemanjs/grunt-contrib-sass#cac384efe5facc3dcd44e947925239b3d9cd2252",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "chalk": "1.1.3",
-        "cross-spawn": "0.2.9",
-        "dargs": "4.1.0",
-        "which": "1.2.14"
+        "async": "^0.9.0",
+        "chalk": "^1.0.0",
+        "cross-spawn": "^0.2.3",
+        "dargs": "^4.0.0",
+        "which": "^1.0.5"
       },
       "dependencies": {
         "async": {
@@ -2431,7 +2433,7 @@
           "integrity": "sha1-vWf5bAfvtjA7f+lMHpefiEeOCjk=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3"
+            "lru-cache": "^2.5.0"
           }
         },
         "lru-cache": {
@@ -2448,8 +2450,8 @@
       "integrity": "sha1-URE/KKckMlIeNeY/fxiiUf2i/Uk=",
       "dev": true,
       "requires": {
-        "grunt-lib-contrib": "0.6.1",
-        "uglify-js": "2.4.24"
+        "grunt-lib-contrib": "~0.6.1",
+        "uglify-js": "~2.4.0"
       },
       "dependencies": {
         "async": {
@@ -2470,7 +2472,7 @@
           "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "uglify-js": {
@@ -2479,10 +2481,10 @@
           "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
           "dev": true,
           "requires": {
-            "async": "0.2.10",
+            "async": "~0.2.6",
             "source-map": "0.1.34",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.5.4"
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.5.4"
           }
         },
         "wordwrap": {
@@ -2497,8 +2499,8 @@
           "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0",
             "wordwrap": "0.0.2"
           }
@@ -2511,9 +2513,9 @@
       "integrity": "sha1-l57nV7muNbS7i3bMEkc9JCHfBPY=",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "request": "2.34.0",
-        "w3cjs": "0.1.25"
+        "colors": "~0.6.0",
+        "request": "~2.34.0",
+        "w3cjs": "~0.1.25"
       },
       "dependencies": {
         "colors": {
@@ -2545,11 +2547,11 @@
       "integrity": "sha1-+4bxgJhHvAfcR4Q/ns1srLYt8tU=",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
-        "grunt-legacy-log-utils": "1.0.0",
-        "hooker": "0.2.3",
-        "lodash": "3.10.1",
-        "underscore.string": "3.2.3"
+        "colors": "~1.1.2",
+        "grunt-legacy-log-utils": "~1.0.0",
+        "hooker": "~0.2.3",
+        "lodash": "~3.10.1",
+        "underscore.string": "~3.2.3"
       }
     },
     "grunt-legacy-log-utils": {
@@ -2558,8 +2560,8 @@
       "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "lodash": "4.3.0"
+        "chalk": "~1.1.1",
+        "lodash": "~4.3.0"
       },
       "dependencies": {
         "lodash": {
@@ -2576,13 +2578,13 @@
       "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "exit": "0.1.2",
-        "getobject": "0.1.0",
-        "hooker": "0.2.3",
-        "lodash": "4.3.0",
-        "underscore.string": "3.2.3",
-        "which": "1.2.14"
+        "async": "~1.5.2",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.3.0",
+        "underscore.string": "~3.2.3",
+        "which": "~1.2.1"
       },
       "dependencies": {
         "lodash": {
@@ -2608,15 +2610,15 @@
       "integrity": "sha1-n/QqvbiORbd1cmIGPj92ruBjbm0=",
       "dev": true,
       "requires": {
-        "coffee-script": "1.8.0",
-        "grunt": "0.4.5",
-        "highlight.js": "9.12.0",
-        "marked": "0.3.17",
-        "moment": "2.8.4",
-        "pug": "2.0.0-rc.4",
-        "rss": "1.0.1",
-        "underscore": "1.7.0",
-        "underscore.string": "2.3.3"
+        "coffee-script": "~1.8.0",
+        "grunt": "~0.4.1",
+        "highlight.js": "^9.7.0",
+        "marked": "^0.3.6",
+        "moment": "~2.8.3",
+        "pug": "^2.0.0-beta6",
+        "rss": "~1.0.0",
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.3.3"
       },
       "dependencies": {
         "argparse": {
@@ -2625,8 +2627,8 @@
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true,
           "requires": {
-            "underscore": "1.7.0",
-            "underscore.string": "2.4.0"
+            "underscore": "~1.7.0",
+            "underscore.string": "~2.4.0"
           },
           "dependencies": {
             "underscore.string": {
@@ -2649,7 +2651,7 @@
           "integrity": "sha1-nJ8dK0pSoADe0Vtll5FwNkgmPB0=",
           "dev": true,
           "requires": {
-            "mkdirp": "0.3.5"
+            "mkdirp": "~0.3.5"
           }
         },
         "colors": {
@@ -2676,8 +2678,8 @@
           "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
           "dev": true,
           "requires": {
-            "glob": "3.2.11",
-            "lodash": "2.4.2"
+            "glob": "~3.2.9",
+            "lodash": "~2.4.1"
           },
           "dependencies": {
             "glob": {
@@ -2686,8 +2688,8 @@
               "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
               "dev": true,
               "requires": {
-                "inherits": "2.0.3",
-                "minimatch": "0.3.0"
+                "inherits": "2",
+                "minimatch": "0.3"
               }
             },
             "lodash": {
@@ -2702,8 +2704,8 @@
               "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
               "dev": true,
               "requires": {
-                "lru-cache": "2.3.1",
-                "sigmund": "1.0.1"
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
               }
             }
           }
@@ -2714,9 +2716,9 @@
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
+            "graceful-fs": "~1.2.0",
+            "inherits": "1",
+            "minimatch": "~0.2.11"
           },
           "dependencies": {
             "inherits": {
@@ -2739,26 +2741,26 @@
           "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
           "dev": true,
           "requires": {
-            "async": "0.1.22",
-            "coffee-script": "1.3.3",
-            "colors": "0.6.2",
+            "async": "~0.1.22",
+            "coffee-script": "~1.3.3",
+            "colors": "~0.6.2",
             "dateformat": "1.0.2-1.2.3",
-            "eventemitter2": "0.4.14",
-            "exit": "0.1.2",
-            "findup-sync": "0.1.3",
-            "getobject": "0.1.0",
-            "glob": "3.1.21",
-            "grunt-legacy-log": "0.1.3",
-            "grunt-legacy-util": "0.2.0",
-            "hooker": "0.2.3",
-            "iconv-lite": "0.2.11",
-            "js-yaml": "2.0.5",
-            "lodash": "0.9.2",
-            "minimatch": "0.2.14",
-            "nopt": "1.0.10",
-            "rimraf": "2.2.8",
-            "underscore.string": "2.2.1",
-            "which": "1.0.9"
+            "eventemitter2": "~0.4.13",
+            "exit": "~0.1.1",
+            "findup-sync": "~0.1.2",
+            "getobject": "~0.1.0",
+            "glob": "~3.1.21",
+            "grunt-legacy-log": "~0.1.0",
+            "grunt-legacy-util": "~0.2.0",
+            "hooker": "~0.2.3",
+            "iconv-lite": "~0.2.11",
+            "js-yaml": "~2.0.5",
+            "lodash": "~0.9.2",
+            "minimatch": "~0.2.12",
+            "nopt": "~1.0.10",
+            "rimraf": "~2.2.8",
+            "underscore.string": "~2.2.1",
+            "which": "~1.0.5"
           },
           "dependencies": {
             "coffee-script": {
@@ -2781,11 +2783,11 @@
           "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
           "dev": true,
           "requires": {
-            "colors": "0.6.2",
-            "grunt-legacy-log-utils": "0.1.1",
-            "hooker": "0.2.3",
-            "lodash": "2.4.2",
-            "underscore.string": "2.3.3"
+            "colors": "~0.6.2",
+            "grunt-legacy-log-utils": "~0.1.1",
+            "hooker": "~0.2.3",
+            "lodash": "~2.4.1",
+            "underscore.string": "~2.3.3"
           },
           "dependencies": {
             "lodash": {
@@ -2802,9 +2804,9 @@
           "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
           "dev": true,
           "requires": {
-            "colors": "0.6.2",
-            "lodash": "2.4.2",
-            "underscore.string": "2.3.3"
+            "colors": "~0.6.2",
+            "lodash": "~2.4.1",
+            "underscore.string": "~2.3.3"
           },
           "dependencies": {
             "lodash": {
@@ -2821,13 +2823,13 @@
           "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
           "dev": true,
           "requires": {
-            "async": "0.1.22",
-            "exit": "0.1.2",
-            "getobject": "0.1.0",
-            "hooker": "0.2.3",
-            "lodash": "0.9.2",
-            "underscore.string": "2.2.1",
-            "which": "1.0.9"
+            "async": "~0.1.22",
+            "exit": "~0.1.1",
+            "getobject": "~0.1.0",
+            "hooker": "~0.2.3",
+            "lodash": "~0.9.2",
+            "underscore.string": "~2.2.1",
+            "which": "~1.0.5"
           },
           "dependencies": {
             "underscore.string": {
@@ -2850,8 +2852,8 @@
           "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
           "dev": true,
           "requires": {
-            "argparse": "0.1.16",
-            "esprima": "1.0.4"
+            "argparse": "~ 0.1.11",
+            "esprima": "~ 1.0.2"
           }
         },
         "lodash": {
@@ -2866,8 +2868,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.3.1",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         },
         "mkdirp": {
@@ -2882,7 +2884,7 @@
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true,
           "requires": {
-            "abbrev": "1.1.1"
+            "abbrev": "1"
           }
         },
         "underscore": {
@@ -2911,9 +2913,9 @@
       "integrity": "sha1-+4e2yqxG+zLUUXf9Lktv90aMGRk=",
       "dev": true,
       "requires": {
-        "each-async": "1.1.1",
-        "node-sass": "3.13.1",
-        "object-assign": "4.1.1"
+        "each-async": "^1.0.0",
+        "node-sass": "^3.7.0",
+        "object-assign": "^4.0.1"
       }
     },
     "grunt-watch-nospawn": {
@@ -2932,8 +2934,8 @@
           "integrity": "sha1-xJERjy+HGRLa4b1bNXVsoBcv8A0=",
           "dev": true,
           "requires": {
-            "fileset": "0.1.8",
-            "minimatch": "0.2.14"
+            "fileset": "~0.1.5",
+            "minimatch": "~0.2.9"
           }
         },
         "minimatch": {
@@ -2942,8 +2944,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.3.1",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -2954,8 +2956,8 @@
       "integrity": "sha1-npsTCpPjiUkTItl1zz7BgYw3zjQ=",
       "dev": true,
       "requires": {
-        "optimist": "0.3.7",
-        "uglify-js": "2.3.6"
+        "optimist": "~0.3",
+        "uglify-js": "~2.3"
       },
       "dependencies": {
         "optimist": {
@@ -2964,7 +2966,7 @@
           "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
           "dev": true,
           "requires": {
-            "wordwrap": "0.0.3"
+            "wordwrap": "~0.0.2"
           }
         }
       }
@@ -2981,8 +2983,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -2991,7 +2993,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -3000,7 +3002,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary": {
@@ -3045,10 +3047,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "boom": "0.4.2",
-        "cryptiles": "0.2.2",
-        "hoek": "0.9.1",
-        "sntp": "0.2.4"
+        "boom": "0.4.x",
+        "cryptiles": "0.2.x",
+        "hoek": "0.9.x",
+        "sntp": "0.2.x"
       }
     },
     "highlight.js": {
@@ -3099,7 +3101,7 @@
           "integrity": "sha1-UNFlGGiuYOzP8KLZ80WVN2vGsEE=",
           "dev": true,
           "requires": {
-            "keypress": "0.1.0"
+            "keypress": "0.1.x"
           }
         }
       }
@@ -3110,11 +3112,11 @@
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
       },
       "dependencies": {
         "isarray": {
@@ -3129,10 +3131,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3152,7 +3154,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": ">= 1.3.1 < 2"
       },
       "dependencies": {
         "depd": {
@@ -3175,10 +3177,10 @@
       "integrity": "sha1-csqdUDp14GRlAITFjKEbguSwGW0=",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "optimist": "0.3.7",
-        "pkginfo": "0.2.3",
-        "utile": "0.1.7"
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x",
+        "utile": "~0.1.7"
       },
       "dependencies": {
         "colors": {
@@ -3193,7 +3195,7 @@
           "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
           "dev": true,
           "requires": {
-            "wordwrap": "0.0.3"
+            "wordwrap": "~0.0.2"
           }
         }
       }
@@ -3204,9 +3206,9 @@
       "integrity": "sha1-4X/aZfCQLZUs55IeYsf/iGJlWl4=",
       "dev": true,
       "requires": {
-        "agent-base": "1.0.2",
-        "debug": "2.6.9",
-        "extend": "3.0.1"
+        "agent-base": "~1.0.1",
+        "debug": "2",
+        "extend": "3"
       },
       "dependencies": {
         "debug": {
@@ -3228,7 +3230,7 @@
       "optional": true,
       "requires": {
         "asn1": "0.1.11",
-        "assert-plus": "0.1.5",
+        "assert-plus": "^0.1.5",
         "ctype": "0.5.3"
       }
     },
@@ -3238,9 +3240,9 @@
       "integrity": "sha1-cT+jjl01P1DrFKNC/r4pAz7RYZs=",
       "dev": true,
       "requires": {
-        "agent-base": "1.0.2",
-        "debug": "2.6.9",
-        "extend": "3.0.1"
+        "agent-base": "~1.0.1",
+        "debug": "2",
+        "extend": "3"
       },
       "dependencies": {
         "debug": {
@@ -3260,7 +3262,7 @@
       "integrity": "sha1-/NdC8z/OvST8PKk6RFAn6KZkL1s=",
       "dev": true,
       "requires": {
-        "comerr": "0.0.9"
+        "comerr": "0.0.x"
       }
     },
     "i": {
@@ -3287,7 +3289,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "indexof": {
@@ -3302,8 +3304,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -3342,7 +3344,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-expression": {
@@ -3351,8 +3353,8 @@
       "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13",
-        "object-assign": "4.1.1"
+        "acorn": "~4.0.2",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -3369,7 +3371,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -3378,7 +3380,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-promise": {
@@ -3393,7 +3395,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-type": {
@@ -3402,7 +3404,7 @@
       "integrity": "sha1-9lHYXDZdRJVdFKUdjXBh8/a0d5w=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2"
+        "core-util-is": "~1.0.0"
       }
     },
     "is-typedarray": {
@@ -3453,8 +3455,8 @@
       "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "2.7.3"
+        "argparse": "^1.0.2",
+        "esprima": "^2.6.0"
       }
     },
     "js2coffee": {
@@ -3463,10 +3465,10 @@
       "integrity": "sha1-xGvU4+oZyG72qE0n96kZm1nK1cc=",
       "dev": true,
       "requires": {
-        "coffee-script": "1.7.1",
-        "file": "0.2.2",
-        "nopt": "3.0.6",
-        "underscore": "1.6.0"
+        "coffee-script": "~1.7.1",
+        "file": "~0.2.1",
+        "nopt": "~3.0.1",
+        "underscore": "~1.6.0"
       },
       "dependencies": {
         "coffee-script": {
@@ -3475,7 +3477,7 @@
           "integrity": "sha1-YplqhheAx15tUGnROCJyO3NAS/w=",
           "dev": true,
           "requires": {
-            "mkdirp": "0.3.5"
+            "mkdirp": "~0.3.5"
           }
         },
         "mkdirp": {
@@ -3505,12 +3507,12 @@
       "integrity": "sha1-mYe5C4YFVsvH84DVdVoj1QQhNRM=",
       "dev": true,
       "requires": {
-        "cli": "0.4.5",
+        "cli": "0.4.x",
         "esprima": "https://github.com/ariya/esprima/tarball/master",
-        "minimatch": "0.4.0",
-        "peakle": "0.0.1",
-        "shelljs": "0.1.4",
-        "underscore": "1.4.4"
+        "minimatch": "0.x.x",
+        "peakle": "0.0.x",
+        "shelljs": "0.1.x",
+        "underscore": "1.4.x"
       },
       "dependencies": {
         "esprima": {
@@ -3524,8 +3526,8 @@
           "integrity": "sha1-vSx9Bg0sjI/Xzefx8u0tWycP2xs=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.3.1",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -3580,8 +3582,8 @@
       "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0",
-        "promise": "7.3.1"
+        "is-promise": "^2.0.0",
+        "promise": "^7.0.1"
       }
     },
     "keypress": {
@@ -3596,7 +3598,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -3611,7 +3613,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lineman": {
@@ -3623,12 +3625,12 @@
         "coffee-script": "1.6.3",
         "commander": "1.3.2",
         "config-extend": "0.0.6",
-        "connect-livereload": "0.4.1",
+        "connect-livereload": "^0.4.0",
         "express": "3.4.0",
-        "fetcher": "0.2.0",
+        "fetcher": "~0.2.0",
         "grunt": "0.4.5",
-        "grunt-asset-fingerprint": "0.2.1",
-        "grunt-concat-sourcemap": "0.4.3",
+        "grunt-asset-fingerprint": "~0.2.0",
+        "grunt-concat-sourcemap": "~0.4.0",
         "grunt-contrib-clean": "0.5.0",
         "grunt-contrib-coffee": "0.7.0",
         "grunt-contrib-copy": "0.4.1",
@@ -3641,12 +3643,12 @@
         "grunt-watch-nospawn": "0.0.8",
         "http-proxy": "0.10.3",
         "js2coffee": "0.3.3",
-        "lodash": "0.9.2",
-        "normalize-package-data": "0.2.13",
-        "resolve": "0.6.3",
+        "lodash": "~0.9.0",
+        "normalize-package-data": "~0.2.9",
+        "resolve": "~0.6.1",
         "semver": "2.1.0",
         "testem": "0.7.6",
-        "underscore.string": "2.3.3",
+        "underscore.string": "~2.3.3",
         "watch_r-structr-lock": "0.0.1"
       },
       "dependencies": {
@@ -3656,8 +3658,8 @@
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true,
           "requires": {
-            "underscore": "1.7.0",
-            "underscore.string": "2.4.0"
+            "underscore": "~1.7.0",
+            "underscore.string": "~2.4.0"
           },
           "dependencies": {
             "underscore.string": {
@@ -3692,7 +3694,7 @@
           "integrity": "sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=",
           "dev": true,
           "requires": {
-            "keypress": "0.1.0"
+            "keypress": "0.1.x"
           }
         },
         "dateformat": {
@@ -3713,8 +3715,8 @@
           "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
           "dev": true,
           "requires": {
-            "glob": "3.2.11",
-            "lodash": "2.4.2"
+            "glob": "~3.2.9",
+            "lodash": "~2.4.1"
           },
           "dependencies": {
             "glob": {
@@ -3723,8 +3725,8 @@
               "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
               "dev": true,
               "requires": {
-                "inherits": "2.0.3",
-                "minimatch": "0.3.0"
+                "inherits": "2",
+                "minimatch": "0.3"
               }
             },
             "lodash": {
@@ -3739,8 +3741,8 @@
               "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
               "dev": true,
               "requires": {
-                "lru-cache": "2.3.1",
-                "sigmund": "1.0.1"
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
               }
             }
           }
@@ -3751,9 +3753,9 @@
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
+            "graceful-fs": "~1.2.0",
+            "inherits": "1",
+            "minimatch": "~0.2.11"
           },
           "dependencies": {
             "inherits": {
@@ -3776,26 +3778,26 @@
           "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
           "dev": true,
           "requires": {
-            "async": "0.1.22",
-            "coffee-script": "1.3.3",
-            "colors": "0.6.2",
+            "async": "~0.1.22",
+            "coffee-script": "~1.3.3",
+            "colors": "~0.6.2",
             "dateformat": "1.0.2-1.2.3",
-            "eventemitter2": "0.4.14",
-            "exit": "0.1.2",
-            "findup-sync": "0.1.3",
-            "getobject": "0.1.0",
-            "glob": "3.1.21",
-            "grunt-legacy-log": "0.1.3",
-            "grunt-legacy-util": "0.2.0",
-            "hooker": "0.2.3",
-            "iconv-lite": "0.2.11",
-            "js-yaml": "2.0.5",
-            "lodash": "0.9.2",
-            "minimatch": "0.2.14",
-            "nopt": "1.0.10",
-            "rimraf": "2.2.8",
-            "underscore.string": "2.2.1",
-            "which": "1.0.9"
+            "eventemitter2": "~0.4.13",
+            "exit": "~0.1.1",
+            "findup-sync": "~0.1.2",
+            "getobject": "~0.1.0",
+            "glob": "~3.1.21",
+            "grunt-legacy-log": "~0.1.0",
+            "grunt-legacy-util": "~0.2.0",
+            "hooker": "~0.2.3",
+            "iconv-lite": "~0.2.11",
+            "js-yaml": "~2.0.5",
+            "lodash": "~0.9.2",
+            "minimatch": "~0.2.12",
+            "nopt": "~1.0.10",
+            "rimraf": "~2.2.8",
+            "underscore.string": "~2.2.1",
+            "which": "~1.0.5"
           },
           "dependencies": {
             "coffee-script": {
@@ -3818,11 +3820,11 @@
           "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
           "dev": true,
           "requires": {
-            "colors": "0.6.2",
-            "grunt-legacy-log-utils": "0.1.1",
-            "hooker": "0.2.3",
-            "lodash": "2.4.2",
-            "underscore.string": "2.3.3"
+            "colors": "~0.6.2",
+            "grunt-legacy-log-utils": "~0.1.1",
+            "hooker": "~0.2.3",
+            "lodash": "~2.4.1",
+            "underscore.string": "~2.3.3"
           },
           "dependencies": {
             "lodash": {
@@ -3839,9 +3841,9 @@
           "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
           "dev": true,
           "requires": {
-            "colors": "0.6.2",
-            "lodash": "2.4.2",
-            "underscore.string": "2.3.3"
+            "colors": "~0.6.2",
+            "lodash": "~2.4.1",
+            "underscore.string": "~2.3.3"
           },
           "dependencies": {
             "lodash": {
@@ -3858,13 +3860,13 @@
           "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
           "dev": true,
           "requires": {
-            "async": "0.1.22",
-            "exit": "0.1.2",
-            "getobject": "0.1.0",
-            "hooker": "0.2.3",
-            "lodash": "0.9.2",
-            "underscore.string": "2.2.1",
-            "which": "1.0.9"
+            "async": "~0.1.22",
+            "exit": "~0.1.1",
+            "getobject": "~0.1.0",
+            "hooker": "~0.2.3",
+            "lodash": "~0.9.2",
+            "underscore.string": "~2.2.1",
+            "which": "~1.0.5"
           },
           "dependencies": {
             "underscore.string": {
@@ -3887,8 +3889,8 @@
           "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
           "dev": true,
           "requires": {
-            "argparse": "0.1.16",
-            "esprima": "1.0.4"
+            "argparse": "~ 0.1.11",
+            "esprima": "~ 1.0.2"
           }
         },
         "lodash": {
@@ -3903,8 +3905,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.3.1",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         },
         "nopt": {
@@ -3913,7 +3915,7 @@
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true,
           "requires": {
-            "abbrev": "1.1.1"
+            "abbrev": "1"
           }
         },
         "normalize-package-data": {
@@ -3922,9 +3924,9 @@
           "integrity": "sha1-UPn9nnexyEEc0jHbKWLnOWPed00=",
           "dev": true,
           "requires": {
-            "github-url-from-git": "1.1.1",
-            "github-url-from-username-repo": "0.1.0",
-            "semver": "2.1.0"
+            "github-url-from-git": "~1.1.1",
+            "github-url-from-username-repo": "^0.1.0",
+            "semver": "2"
           }
         },
         "resolve": {
@@ -3965,8 +3967,8 @@
       "integrity": "sha1-wFAXzdGFELerv5mZQd18BtU/Tk8=",
       "dev": true,
       "requires": {
-        "coffee-script": "1.6.3",
-        "grunt-markdown-blog": "1.2.0"
+        "coffee-script": "~1.6.3",
+        "grunt-markdown-blog": "^1.2.0"
       },
       "dependencies": {
         "coffee-script": {
@@ -3983,7 +3985,7 @@
       "integrity": "sha1-Bz88QIoj26FWkzsQx/scS0Li2HU=",
       "dev": true,
       "requires": {
-        "grunt-contrib-pug": "1.0.0"
+        "grunt-contrib-pug": "^1.0.0"
       }
     },
     "load-json-file": {
@@ -3992,11 +3994,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "lodash": {
@@ -4047,8 +4049,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -4081,16 +4083,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       }
     },
     "merge-descriptors": {
@@ -4123,7 +4125,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "minimatch": {
@@ -4132,7 +4134,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -4176,8 +4178,8 @@
       "integrity": "sha1-NaMYNDI1eO5l9dhwVoCXkUc5z04=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34",
-        "stream-counter": "0.1.0"
+        "readable-stream": "~1.0.2",
+        "stream-counter": "~0.1.0"
       },
       "dependencies": {
         "isarray": {
@@ -4192,10 +4194,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -4242,19 +4244,19 @@
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.0.6",
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.5",
-        "request": "2.34.0",
-        "rimraf": "2.2.8",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.2.14"
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "2",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
       },
       "dependencies": {
         "semver": {
@@ -4271,22 +4273,22 @@
       "integrity": "sha1-ckD7v/I5YwS0IjUn7TAgWJwAT8I=",
       "dev": true,
       "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
-        "get-stdin": "4.0.1",
-        "glob": "7.0.6",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.9.2",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.2",
-        "request": "2.83.0",
-        "sass-graph": "2.2.4"
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.3.2",
+        "node-gyp": "^3.3.1",
+        "npmlog": "^4.0.0",
+        "request": "^2.61.0",
+        "sass-graph": "^2.1.1"
       },
       "dependencies": {
         "assert-plus": {
@@ -4307,7 +4309,7 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         },
         "combined-stream": {
@@ -4316,7 +4318,7 @@
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "cryptiles": {
@@ -4325,7 +4327,7 @@
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "dev": true,
           "requires": {
-            "boom": "5.2.0"
+            "boom": "5.x.x"
           },
           "dependencies": {
             "boom": {
@@ -4334,7 +4336,7 @@
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
-                "hoek": "4.2.1"
+                "hoek": "4.x.x"
               }
             }
           }
@@ -4357,9 +4359,9 @@
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
+            "asynckit": "^0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
+            "mime-types": "^2.1.12"
           }
         },
         "hawk": {
@@ -4368,10 +4370,10 @@
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.1",
-            "sntp": "2.1.0"
+            "boom": "4.x.x",
+            "cryptiles": "3.x.x",
+            "hoek": "4.x.x",
+            "sntp": "2.x.x"
           }
         },
         "hoek": {
@@ -4386,9 +4388,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "oauth-sign": {
@@ -4409,28 +4411,28 @@
           "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           }
         },
         "sntp": {
@@ -4439,7 +4441,7 @@
           "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         },
         "tunnel-agent": {
@@ -4448,7 +4450,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "uuid": {
@@ -4471,7 +4473,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "noptify": {
@@ -4480,7 +4482,7 @@
       "integrity": "sha1-WPZUpz2XU98MUdlobckhBKZ/S7s=",
       "dev": true,
       "requires": {
-        "nopt": "2.0.0"
+        "nopt": "~2.0.0"
       },
       "dependencies": {
         "nopt": {
@@ -4489,7 +4491,7 @@
           "integrity": "sha1-ynQW8gpeP5w7hhgPlilfo9C1Lg0=",
           "dev": true,
           "requires": {
-            "abbrev": "1.1.1"
+            "abbrev": "1"
           }
         }
       }
@@ -4500,10 +4502,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "npmlog": {
@@ -4512,10 +4514,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -4558,7 +4560,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -4574,8 +4576,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -4605,7 +4607,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -4620,8 +4622,8 @@
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "parse-json": {
@@ -4630,7 +4632,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parsejson": {
@@ -4639,7 +4641,7 @@
       "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseqs": {
@@ -4648,7 +4650,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parserlib": {
@@ -4663,7 +4665,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -4678,7 +4680,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -4699,9 +4701,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pause": {
@@ -4740,7 +4742,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkginfo": {
@@ -4761,7 +4763,7 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "proxy-addr": {
@@ -4770,7 +4772,7 @@
       "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.6.0"
       }
     },
@@ -4780,10 +4782,10 @@
       "integrity": "sha1-NEbQxc/j7FidTGioMeN8q4Lpxw4=",
       "dev": true,
       "requires": {
-        "http-proxy-agent": "0.2.7",
-        "https-proxy-agent": "0.3.6",
-        "lru-cache": "2.3.1",
-        "socks-proxy-agent": "0.1.2"
+        "http-proxy-agent": "0",
+        "https-proxy-agent": "0",
+        "lru-cache": "~2.3.1",
+        "socks-proxy-agent": "0"
       }
     },
     "pseudomap": {
@@ -4798,14 +4800,14 @@
       "integrity": "sha512-SL7xovj6E2Loq9N0UgV6ynjMLW4urTFY/L/Fprhvz13Xc5vjzkjZjI1QHKq31200+6PSD8PyU6MqrtCTJj6/XA==",
       "dev": true,
       "requires": {
-        "pug-code-gen": "2.0.0",
-        "pug-filters": "2.1.5",
-        "pug-lexer": "3.1.0",
-        "pug-linker": "3.0.3",
-        "pug-load": "2.0.9",
-        "pug-parser": "4.0.0",
-        "pug-runtime": "2.0.3",
-        "pug-strip-comments": "1.0.2"
+        "pug-code-gen": "^2.0.0",
+        "pug-filters": "^2.1.5",
+        "pug-lexer": "^3.1.0",
+        "pug-linker": "^3.0.3",
+        "pug-load": "^2.0.9",
+        "pug-parser": "^4.0.0",
+        "pug-runtime": "^2.0.3",
+        "pug-strip-comments": "^1.0.2"
       }
     },
     "pug-attrs": {
@@ -4814,9 +4816,9 @@
       "integrity": "sha1-i+KyIlVo/6ddG4Zpgr/59BEa/8s=",
       "dev": true,
       "requires": {
-        "constantinople": "3.1.2",
-        "js-stringify": "1.0.2",
-        "pug-runtime": "2.0.3"
+        "constantinople": "^3.0.1",
+        "js-stringify": "^1.0.1",
+        "pug-runtime": "^2.0.3"
       }
     },
     "pug-code-gen": {
@@ -4825,14 +4827,14 @@
       "integrity": "sha512-E4oiJT+Jn5tyEIloj8dIJQognbiNNp0i0cAJmYtQTFS0soJ917nlIuFtqVss3IXMEyQKUew3F4gIkBpn18KbVg==",
       "dev": true,
       "requires": {
-        "constantinople": "3.1.2",
-        "doctypes": "1.1.0",
-        "js-stringify": "1.0.2",
-        "pug-attrs": "2.0.2",
-        "pug-error": "1.3.2",
-        "pug-runtime": "2.0.3",
-        "void-elements": "2.0.1",
-        "with": "5.1.1"
+        "constantinople": "^3.0.1",
+        "doctypes": "^1.1.0",
+        "js-stringify": "^1.0.1",
+        "pug-attrs": "^2.0.2",
+        "pug-error": "^1.3.2",
+        "pug-runtime": "^2.0.3",
+        "void-elements": "^2.0.1",
+        "with": "^5.0.0"
       }
     },
     "pug-error": {
@@ -4847,13 +4849,13 @@
       "integrity": "sha512-xkw71KtrC4sxleKiq+cUlQzsiLn8pM5+vCgkChW2E6oNOzaqTSIBKIQ5cl4oheuDzvJYCTSYzRaVinMUrV4YLQ==",
       "dev": true,
       "requires": {
-        "clean-css": "3.4.28",
-        "constantinople": "3.1.2",
+        "clean-css": "^3.3.0",
+        "constantinople": "^3.0.1",
         "jstransformer": "1.0.0",
-        "pug-error": "1.3.2",
-        "pug-walk": "1.1.5",
-        "resolve": "1.1.7",
-        "uglify-js": "2.8.29"
+        "pug-error": "^1.3.2",
+        "pug-walk": "^1.1.5",
+        "resolve": "^1.1.6",
+        "uglify-js": "^2.6.1"
       },
       "dependencies": {
         "camelcase": {
@@ -4868,8 +4870,8 @@
           "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
           "dev": true,
           "requires": {
-            "commander": "2.8.1",
-            "source-map": "0.4.4"
+            "commander": "2.8.x",
+            "source-map": "0.4.x"
           }
         },
         "cliui": {
@@ -4878,8 +4880,8 @@
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           }
         },
@@ -4889,7 +4891,7 @@
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "uglify-js": {
@@ -4898,9 +4900,9 @@
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "source-map": {
@@ -4923,9 +4925,9 @@
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -4937,9 +4939,9 @@
       "integrity": "sha1-/QhzdtSmdbT1n4/vQiiDQ06VgaI=",
       "dev": true,
       "requires": {
-        "character-parser": "2.2.0",
-        "is-expression": "3.0.0",
-        "pug-error": "1.3.2"
+        "character-parser": "^2.1.1",
+        "is-expression": "^3.0.0",
+        "pug-error": "^1.3.2"
       }
     },
     "pug-linker": {
@@ -4948,8 +4950,8 @@
       "integrity": "sha512-DCKczglCXOzJ1lr4xUj/lVHYvS+lGmR2+KTCjZjtIpdwaN7lNOoX2SW6KFX5X4ElvW+6ThwB+acSUg08UJFN5A==",
       "dev": true,
       "requires": {
-        "pug-error": "1.3.2",
-        "pug-walk": "1.1.5"
+        "pug-error": "^1.3.2",
+        "pug-walk": "^1.1.5"
       }
     },
     "pug-load": {
@@ -4958,8 +4960,8 @@
       "integrity": "sha512-BDdZOCru4mg+1MiZwRQZh25+NTRo/R6/qArrdWIf308rHtWA5N9kpoUskRe4H6FslaQujC+DigH9LqlBA4gf6Q==",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "pug-walk": "1.1.5"
+        "object-assign": "^4.1.0",
+        "pug-walk": "^1.1.5"
       }
     },
     "pug-parser": {
@@ -4968,7 +4970,7 @@
       "integrity": "sha512-ocEUFPdLG9awwFj0sqi1uiZLNvfoodCMULZzkRqILryIWc/UUlDlxqrKhKjAIIGPX/1SNsvxy63+ayEGocGhQg==",
       "dev": true,
       "requires": {
-        "pug-error": "1.3.2",
+        "pug-error": "^1.3.2",
         "token-stream": "0.0.1"
       }
     },
@@ -4984,7 +4986,7 @@
       "integrity": "sha1-0xOvoBvMN0mA4TmeI+vy65vchRM=",
       "dev": true,
       "requires": {
-        "pug-error": "1.3.2"
+        "pug-error": "^1.3.2"
       }
     },
     "pug-walk": {
@@ -5011,7 +5013,7 @@
       "integrity": "sha1-WJRwXvpfIpn26SHOlQ5CMb0SOtI=",
       "dev": true,
       "requires": {
-        "debug": "2.2.0"
+        "debug": "~2.2.0"
       },
       "dependencies": {
         "debug": {
@@ -5063,9 +5065,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -5074,8 +5076,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -5084,13 +5086,13 @@
       "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "redent": {
@@ -5099,8 +5101,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "reduce-component": {
@@ -5127,7 +5129,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -5136,18 +5138,18 @@
       "integrity": "sha1-tdi5UmrdSi1GKfTUFxJFc5lkRa4=",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.5.0",
-        "forever-agent": "0.5.2",
-        "form-data": "0.1.4",
-        "hawk": "1.0.0",
-        "http-signature": "0.10.1",
-        "json-stringify-safe": "5.0.1",
-        "mime": "1.2.11",
-        "node-uuid": "1.4.8",
-        "oauth-sign": "0.3.0",
-        "qs": "0.6.6",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.3.0"
+        "aws-sign2": "~0.5.0",
+        "forever-agent": "~0.5.0",
+        "form-data": "~0.1.0",
+        "hawk": "~1.0.0",
+        "http-signature": "~0.10.0",
+        "json-stringify-safe": "~5.0.0",
+        "mime": "~1.2.9",
+        "node-uuid": "~1.4.0",
+        "oauth-sign": "~0.3.0",
+        "qs": "~0.6.0",
+        "tough-cookie": ">=0.12.0",
+        "tunnel-agent": "~0.3.0"
       }
     },
     "require-directory": {
@@ -5180,7 +5182,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -5195,8 +5197,8 @@
       "integrity": "sha1-63KokwsioOVeKo5qPVl2KF4Sfq0=",
       "dev": true,
       "requires": {
-        "mime": "1.2.11",
-        "xml": "1.0.1"
+        "mime": "^1.2.11",
+        "xml": "^1.0.0"
       }
     },
     "runforcover": {
@@ -5205,7 +5207,7 @@
       "integrity": "sha1-NE8FfY1F0zrrxsyCIEZ49pxIV8w=",
       "dev": true,
       "requires": {
-        "bunker": "0.1.2"
+        "bunker": "0.1.X"
       }
     },
     "safe-buffer": {
@@ -5220,10 +5222,10 @@
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
-        "glob": "7.0.6",
-        "lodash": "4.17.5",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^7.0.0"
       },
       "dependencies": {
         "lodash": {
@@ -5240,8 +5242,8 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.4.3",
-        "source-map": "0.4.4"
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
       }
     },
     "semver": {
@@ -5256,9 +5258,9 @@
       "integrity": "sha1-vnDY0b4B3mGCGvE3gLUDRaT3Gr0=",
       "dev": true,
       "requires": {
-        "debug": "0.7.4",
+        "debug": "*",
         "fresh": "0.2.0",
-        "mime": "1.2.11",
+        "mime": "~1.2.9",
         "range-parser": "0.0.4"
       }
     },
@@ -5268,9 +5270,9 @@
       "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.1"
       },
       "dependencies": {
@@ -5308,18 +5310,18 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.1",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "1.6.2",
+            "http-errors": "~1.6.2",
             "mime": "1.4.1",
             "ms": "2.0.0",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.3.1"
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.3.1"
           }
         }
       }
@@ -5373,7 +5375,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "hoek": "0.9.1"
+        "hoek": "0.9.x"
       }
     },
     "socket.io": {
@@ -5383,7 +5385,7 @@
       "dev": true,
       "requires": {
         "debug": "2.3.3",
-        "engine.io": "1.8.5",
+        "engine.io": "~1.8.4",
         "has-binary": "0.1.7",
         "object-assign": "4.1.0",
         "socket.io-adapter": "0.5.0",
@@ -5451,7 +5453,7 @@
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
         "debug": "2.3.3",
-        "engine.io-client": "1.8.5",
+        "engine.io-client": "~1.8.4",
         "has-binary": "0.1.7",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
@@ -5524,9 +5526,9 @@
       "integrity": "sha1-6JgUhjYIlvaS9gC6Uql0yLI9wSE=",
       "dev": true,
       "requires": {
-        "agent-base": "1.0.2",
-        "extend": "1.2.1",
-        "rainbowsocks": "0.1.3"
+        "agent-base": "~1.0.1",
+        "extend": "~1.2.1",
+        "rainbowsocks": "~0.1.2"
       },
       "dependencies": {
         "extend": {
@@ -5543,7 +5545,7 @@
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "dev": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "spdx-correct": {
@@ -5552,8 +5554,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -5568,8 +5570,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -5590,14 +5592,14 @@
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       },
       "dependencies": {
         "asn1": {
@@ -5626,7 +5628,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "~0.1.1"
       }
     },
     "stream-counter": {
@@ -5635,7 +5637,7 @@
       "integrity": "sha1-oDXkKTYftX82Fgbhf82Ki5Z3Mns=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "~1.0.2"
       },
       "dependencies": {
         "isarray": {
@@ -5650,10 +5652,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -5670,9 +5672,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -5681,7 +5683,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -5696,7 +5698,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -5705,7 +5707,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-indent": {
@@ -5714,7 +5716,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -5742,7 +5744,7 @@
       "dev": true,
       "requires": {
         "cookiejar": "1.3.0",
-        "debug": "0.7.4",
+        "debug": "~0.7.2",
         "emitter-component": "1.0.0",
         "formidable": "1.0.14",
         "methods": "0.0.1",
@@ -5771,7 +5773,7 @@
       "integrity": "sha1-kh18StOX1gZVPVd5+ldu4uXGv4I=",
       "dev": true,
       "requires": {
-        "proxy-agent": "0.0.2"
+        "proxy-agent": "~0.0.2"
       }
     },
     "supports-color": {
@@ -5786,16 +5788,16 @@
       "integrity": "sha1-dVV9goW4eu9hkCto+3gvpNxl7dQ=",
       "dev": true,
       "requires": {
-        "buffer-equal": "0.0.2",
-        "deep-equal": "1.0.1",
-        "difflet": "0.2.6",
-        "glob": "4.5.3",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "runforcover": "0.0.2",
-        "slide": "1.1.6",
-        "yamlish": "0.0.7"
+        "buffer-equal": "~0.0.0",
+        "deep-equal": "^1.0.0",
+        "difflet": "~0.2.0",
+        "glob": "^4.3.5",
+        "inherits": "*",
+        "mkdirp": "^0.5.0",
+        "nopt": "^3.0.1",
+        "runforcover": "~0.0.2",
+        "slide": "*",
+        "yamlish": "*"
       },
       "dependencies": {
         "glob": {
@@ -5804,10 +5806,10 @@
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
           }
         },
         "minimatch": {
@@ -5816,7 +5818,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.0.0"
           }
         }
       }
@@ -5827,9 +5829,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tempfile": {
@@ -5838,11 +5840,12 @@
       "integrity": "sha1-fWtxAEcznTn4RzJ6BW2t8YMQMBA=",
       "dev": true,
       "requires": {
-        "uuid": "1.4.2"
+        "uuid": "~1.4.0"
       }
     },
     "testdouble-style": {
       "version": "github:testdouble/style#f271e5becc5dc28535dfc2790ab31fab3428d35f",
+      "from": "testdouble-style@github:testdouble/style#f271e5becc5dc28535dfc2790ab31fab3428d35f",
       "dev": true
     },
     "testem": {
@@ -5851,29 +5854,29 @@
       "integrity": "sha1-OpZAvdyEe8VqlydOhBf+NE0NRo8=",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "backbone": "1.3.3",
-        "charm": "1.0.2",
-        "colors": "1.1.2",
-        "commander": "2.14.1",
-        "consolidate": "0.11.0",
-        "cross-spawn": "0.2.9",
+        "async": "^0.9.0",
+        "backbone": "^1.1.2",
+        "charm": "^1.0.0",
+        "colors": "^1.0.3",
+        "commander": "^2.6.0",
+        "consolidate": "^0.11.0",
+        "cross-spawn": "^0.2.6",
         "did_it_work": "0.0.6",
-        "express": "4.16.2",
-        "fileset": "0.1.8",
-        "fireworm": "0.6.6",
-        "glob": "4.5.3",
-        "growl": "1.10.4",
-        "http-proxy": "1.16.2",
-        "js-yaml": "3.5.5",
-        "mkdirp": "0.5.1",
-        "mustache": "1.2.0",
-        "npmlog": "1.2.1",
-        "rimraf": "2.2.8",
-        "socket.io": "1.7.4",
+        "express": "^4.10.7",
+        "fileset": "^0.1.5",
+        "fireworm": "^0.6.6",
+        "glob": "^4.3.5",
+        "growl": "^1.8.1",
+        "http-proxy": "^1.8.1",
+        "js-yaml": "^3.2.5",
+        "mkdirp": "^0.5.0",
+        "mustache": "^1.0.0",
+        "npmlog": "^1.0.0",
+        "rimraf": "^2.2.8",
+        "socket.io": "^1.3.4",
         "styled_string": "0.0.1",
-        "tap": "0.6.0",
-        "xml-escape": "1.1.0"
+        "tap": "^0.6.0",
+        "xml-escape": "^1.0.0"
       },
       "dependencies": {
         "are-we-there-yet": {
@@ -5882,8 +5885,8 @@
           "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
           "dev": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.4"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.0 || ^1.1.13"
           }
         },
         "async": {
@@ -5916,7 +5919,7 @@
           "integrity": "sha1-vWf5bAfvtjA7f+lMHpefiEeOCjk=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3"
+            "lru-cache": "^2.5.0"
           }
         },
         "debug": {
@@ -5934,36 +5937,36 @@
           "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
           "dev": true,
           "requires": {
-            "accepts": "1.3.5",
+            "accepts": "~1.3.4",
             "array-flatten": "1.1.1",
             "body-parser": "1.18.2",
             "content-disposition": "0.5.2",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.4",
             "cookie": "0.3.1",
             "cookie-signature": "1.0.6",
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.1",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "finalhandler": "1.1.0",
             "fresh": "0.5.2",
             "merge-descriptors": "1.0.1",
-            "methods": "1.1.2",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
             "path-to-regexp": "0.1.7",
-            "proxy-addr": "2.0.3",
+            "proxy-addr": "~2.0.2",
             "qs": "6.5.1",
-            "range-parser": "1.2.0",
+            "range-parser": "~1.2.0",
             "safe-buffer": "5.1.1",
             "send": "0.16.1",
             "serve-static": "1.13.1",
             "setprototypeof": "1.1.0",
-            "statuses": "1.3.1",
-            "type-is": "1.6.16",
+            "statuses": "~1.3.1",
+            "type-is": "~1.6.15",
             "utils-merge": "1.0.1",
-            "vary": "1.1.2"
+            "vary": "~1.1.2"
           }
         },
         "fresh": {
@@ -5978,11 +5981,11 @@
           "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "has-unicode": "2.0.1",
-            "lodash.pad": "4.5.1",
-            "lodash.padend": "4.6.1",
-            "lodash.padstart": "4.6.1"
+            "ansi": "^0.3.0",
+            "has-unicode": "^2.0.0",
+            "lodash.pad": "^4.1.0",
+            "lodash.padend": "^4.1.0",
+            "lodash.padstart": "^4.1.0"
           }
         },
         "glob": {
@@ -5991,10 +5994,10 @@
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
           }
         },
         "http-proxy": {
@@ -6003,8 +6006,8 @@
           "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
           "dev": true,
           "requires": {
-            "eventemitter3": "1.2.0",
-            "requires-port": "1.0.0"
+            "eventemitter3": "1.x.x",
+            "requires-port": "1.x.x"
           }
         },
         "lru-cache": {
@@ -6031,7 +6034,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.0.0"
           }
         },
         "npmlog": {
@@ -6040,9 +6043,9 @@
           "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "are-we-there-yet": "1.0.6",
-            "gauge": "1.2.7"
+            "ansi": "~0.3.0",
+            "are-we-there-yet": "~1.0.0",
+            "gauge": "~1.2.0"
           }
         },
         "qs": {
@@ -6064,18 +6067,18 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.1",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "1.6.2",
+            "http-errors": "~1.6.2",
             "mime": "1.4.1",
             "ms": "2.0.0",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.3.1"
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.3.1"
           }
         }
       }
@@ -6086,10 +6089,10 @@
       "integrity": "sha1-Hpnh4qhGm3NquX2X7vqYxx927Qo=",
       "dev": true,
       "requires": {
-        "debug": "0.7.4",
-        "faye-websocket": "0.4.4",
-        "noptify": "0.0.3",
-        "qs": "0.5.6"
+        "debug": "~0.7.0",
+        "faye-websocket": "~0.4.3",
+        "noptify": "~0.0.3",
+        "qs": "~0.5.2"
       },
       "dependencies": {
         "qs": {
@@ -6124,7 +6127,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tq": {
@@ -6133,7 +6136,7 @@
       "integrity": "sha1-eFyuyUiTdRcyvcfWi5DS3x6YW+0=",
       "dev": true,
       "requires": {
-        "hurryup": "0.0.8"
+        "hurryup": "0.0.x"
       }
     },
     "traverse": {
@@ -6169,7 +6172,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       }
     },
     "uglify-js": {
@@ -6179,9 +6182,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "0.2.10",
-        "optimist": "0.3.7",
-        "source-map": "0.1.43"
+        "async": "~0.2.6",
+        "optimist": "~0.3.5",
+        "source-map": "~0.1.7"
       },
       "dependencies": {
         "async": {
@@ -6198,7 +6201,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "wordwrap": "0.0.3"
+            "wordwrap": "~0.0.2"
           }
         },
         "source-map": {
@@ -6208,7 +6211,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -6261,12 +6264,12 @@
       "integrity": "sha1-VdsYDVRHUzn9bdni0UpMC1JiS2k=",
       "dev": true,
       "requires": {
-        "async": "0.1.22",
-        "deep-equal": "1.0.1",
-        "i": "0.3.6",
-        "mkdirp": "0.5.1",
-        "ncp": "0.2.7",
-        "rimraf": "1.0.9"
+        "async": "0.1.x",
+        "deep-equal": "*",
+        "i": "0.3.x",
+        "mkdirp": "0.x.x",
+        "ncp": "0.2.x",
+        "rimraf": "1.x.x"
       },
       "dependencies": {
         "async": {
@@ -6301,8 +6304,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vary": {
@@ -6317,9 +6320,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -6342,9 +6345,9 @@
       "integrity": "sha1-qMv3uF2Czfa4RLTVwufwVBaUmxg=",
       "dev": true,
       "requires": {
-        "commander": "2.0.0",
-        "superagent": "0.15.7",
-        "superagent-proxy": "0.2.0"
+        "commander": "~2.0.0",
+        "superagent": "~0.15.7",
+        "superagent-proxy": "~0.2.0"
       }
     },
     "watch_r-structr-lock": {
@@ -6353,12 +6356,12 @@
       "integrity": "sha1-SxmBEHZUugK87iPlaS+daD+F0Ac=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "commander": "1.1.1",
-        "ejs": "0.8.8",
+        "async": "0.2.x",
+        "commander": "1.1.x",
+        "ejs": "0.8.x",
         "structr": "0.2.3",
-        "tq": "0.2.5",
-        "underscore": "1.4.4"
+        "tq": "0.2.x",
+        "underscore": "1.4.x"
       },
       "dependencies": {
         "async": {
@@ -6373,7 +6376,7 @@
           "integrity": "sha1-UNFlGGiuYOzP8KLZ80WVN2vGsEE=",
           "dev": true,
           "requires": {
-            "keypress": "0.1.0"
+            "keypress": "0.1.x"
           }
         }
       }
@@ -6384,7 +6387,7 @@
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -6399,7 +6402,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
     },
     "window-size": {
@@ -6414,8 +6417,8 @@
       "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0",
-        "acorn-globals": "3.1.0"
+        "acorn": "^3.1.0",
+        "acorn-globals": "^3.0.0"
       }
     },
     "wordwrap": {
@@ -6430,8 +6433,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -6446,8 +6449,8 @@
       "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "dev": true,
       "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
       }
     },
     "wtf-8": {
@@ -6498,19 +6501,19 @@
       "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "5.0.0"
+        "camelcase": "^3.0.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.2",
+        "which-module": "^1.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^5.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -6527,7 +6530,7 @@
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0"
+        "camelcase": "^3.0.0"
       },
       "dependencies": {
         "camelcase": {


### PR DESCRIPTION
Addressing GitHub's notification about security vulnerabilities:

<img width="743" alt="network_dependencies_ _testdouble_double-takes" src="https://user-images.githubusercontent.com/645672/39520919-5e2f52fe-4dda-11e8-92b4-6ac350385ee5.png">
